### PR TITLE
docs: update CLAUDE.md and add README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ uv run behave tests/e2e/features/        # run BDD e2e tests (serial)
 - **Integration tests** (pytest) — `tests/test_integration.py`, mocked embedder
 - **BDD e2e** (behave) — `tests/e2e/features/*.feature`, real server on UDS
   - `knowledge_base.feature` — CLI workflow with mocked embeddings (fast)
+  - `mcp_tools.feature` — MCP protocol tools via FastMCP in-memory Client
   - `semantic_search.feature` (`@real_ollama`) — real Ollama embeddings, verifies
     semantic retrieval accuracy and config-driven labeling
 
@@ -106,10 +107,11 @@ uv run behave tests/e2e/features/        # run BDD e2e tests (serial)
 - `@real_ollama` tag marks tests requiring a running Ollama instance
 - pytest `@pytest.mark.slow` tests are skipped by default (run with `-m slow`)
 
-## Known Gaps
+## CI (GitHub Actions)
 
-- API endpoints lack `response_model` annotations — OpenAPI response schemas are
-  incomplete. Fix by adding Pydantic response models to all endpoints.
+- `ci.yml` — unit tests per-package (skip if unchanged), e2e behind `require-e2e-tests` label
+- `claude-code-review.yml` — Claude review behind `require-claude-review` label
+- `claude.yml` — @claude mentions in PR comments
 
 ## Design Docs
 
@@ -131,3 +133,9 @@ All design documents live under `docs/`, organized by type:
   for inter-package dependencies.
 - Root `pyproject.toml` needs `addopts = "--import-mode=importlib"` for pytest to
   collect tests across multiple packages without `tests` package name collisions.
+- pytest-xdist `-n auto` adds ~26s fork overhead — don't enable by default until
+  the test suite is large enough to benefit. Keep serial, pass `-n auto` explicitly.
+- MCP e2e tests patch `guru_mcp.server._get_client` to point at the test server.
+  The MCP protocol layer (Client -> FastMCP -> CallToolRequest) is fully exercised.
+- behave features run one server per feature (via `before_feature` hook) — features
+  are fully independent and safe to parallelize.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,140 @@
+# Guru
+
+A local-first knowledge-base manager that indexes markdown documents in a git repo and serves them to AI agents via RAG over MCP. Runs entirely on your MacBook with no cloud dependencies.
+
+## What it does
+
+- Indexes markdown files with YAML frontmatter into a vector database (LanceDB)
+- Embeds content using Ollama (nomic-embed-text) running locally
+- Serves knowledge to AI agents via MCP (Model Context Protocol)
+- Provides a CLI for indexing, searching, and retrieving documents
+- Rule-based configuration for labeling and organizing documents
+
+## Architecture
+
+```
+AI Agent (Claude Code / Cursor / Continue.dev)
+    | stdio
+guru-mcp (MCP protocol adapter)
+    | HTTP-over-UDS
+guru-server (FastAPI daemon)
+    |-- LanceDB (embedded vector storage)
+    |-- Ollama (nomic-embed-text embeddings)
+
+Developer terminal
+    |
+guru-cli (click commands / Textual TUI)
+    | HTTP-over-UDS
+guru-server
+```
+
+All state is owned by `guru-server`. Clients (`guru-mcp`, `guru-cli`) connect via HTTP over Unix domain sockets through the shared `guru-core` SDK.
+
+## Prerequisites
+
+- Python >= 3.13
+- [uv](https://docs.astral.sh/uv/) (package manager)
+- [Ollama](https://ollama.com) with `nomic-embed-text` model
+
+```bash
+brew install ollama
+ollama pull nomic-embed-text
+```
+
+## Quick start
+
+```bash
+# Install
+uv sync --all-packages
+
+# Initialize a project
+cd /path/to/your/repo
+uv run guru init
+
+# Index your markdown files
+uv run guru index
+
+# Search
+uv run guru search "authentication flow"
+
+# List indexed documents
+uv run guru list
+```
+
+## Configuration
+
+Create `guru.json` in your project root (or let `guru init` create defaults):
+
+```json
+[
+  {
+    "ruleName": "docs",
+    "match": { "glob": "docs/**/*.md" },
+    "labels": ["documentation"]
+  },
+  {
+    "ruleName": "specs",
+    "match": { "glob": "specs/**/*.md" },
+    "labels": ["spec"]
+  },
+  {
+    "ruleName": "exclude-vendor",
+    "match": { "glob": "vendor/**" },
+    "exclude": true
+  }
+]
+```
+
+Config resolution: `./guru.json` > `./.guru/config.json` > `~/.config/guru/config.json`. Rules merge by `ruleName` (local replaces global, new names appended).
+
+## MCP integration
+
+Add to your `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "guru": {
+      "command": "uv",
+      "args": ["run", "guru-mcp"]
+    }
+  }
+}
+```
+
+Available MCP tools: `search`, `get_document`, `list_documents`, `get_section`, `index_status`.
+
+## CLI commands
+
+```
+guru                     # launch TUI (Phase 3)
+guru init                # initialize .guru/ in current directory
+guru index [PATH]        # index documents
+guru search "query"      # semantic search
+guru doc <path>          # get full document
+guru doc <path> -s "H"   # get specific section
+guru list                # list all indexed documents
+guru config              # show resolved config
+guru server start|stop|status
+```
+
+## Development
+
+```bash
+uv sync --all-packages              # install everything
+uv run pytest                       # unit + integration tests
+uv run behave tests/e2e/features/   # BDD e2e tests
+./scripts/run-behave-parallel.sh    # e2e tests in parallel
+```
+
+## Project structure
+
+```
+packages/
+  guru-core/     shared client SDK (types, discovery, auto-start, HTTP client)
+  guru-server/   FastAPI daemon (LanceDB, Ollama, ingestion, REST API)
+  guru-mcp/      MCP protocol adapter (FastMCP, stdio)
+  guru-cli/      CLI (click) + TUI (Textual)
+```
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full architecture constitution.


### PR DESCRIPTION
## Summary

- Update CLAUDE.md with session learnings (MCP e2e test info, CI section, gotchas)
- Remove stale "Known Gaps" section (response_model was already fixed)
- Add README.md with project overview, quick start, config, MCP integration, CLI commands

## Test plan

- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)