### PR TITLE
feat: packaging and distribution via GitHub Pages

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | { read -r f; if [[ \"$f\" == *.py ]]; then cd \"$(git rev-parse --show-toplevel)\" && uv run ruff check --fix \"$f\" 2>/dev/null; uv run ruff format \"$f\" 2>/dev/null; fi; } || true",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history needed for dunamai version detection
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install build dependencies
+        run: uv sync --all-packages
+
+      - name: Build all wheels
+        run: |
+          mkdir -p dist
+          for pkg in packages/guru-core packages/guru-server packages/guru-mcp packages/guru-cli .; do
+            uv build --directory "$pkg" --out-dir dist/
+          done
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" dist/*.whl \
+            --title "${{ github.ref_name }}" \
+            --generate-notes
+
+      - name: Deploy to GitHub Pages index
+        run: |
+          set -e
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Prepare a temporary working area
+          WORK=$(mktemp -d)
+          PAGES_BRANCH=gh-pages
+
+          # Try to fetch existing gh-pages, or start fresh
+          if git ls-remote --exit-code origin "$PAGES_BRANCH" > /dev/null 2>&1; then
+            git fetch origin "$PAGES_BRANCH"
+            git worktree add "$WORK" "$PAGES_BRANCH"
+          else
+            git worktree add --orphan "$WORK" "$PAGES_BRANCH"
+            # Clean the orphan worktree
+            rm -rf "$WORK"/*
+          fi
+
+          # Copy new wheels
+          mkdir -p "$WORK/wheels"
+          cp dist/*.whl "$WORK/wheels/"
+
+          # Generate index
+          python scripts/generate_index.py "$WORK/wheels" "$WORK/simple"
+
+          # Commit and push
+          cd "$WORK"
+          git add --all
+          if git diff --cached --quiet; then
+            echo "No changes to deploy"
+          else
+            git commit -m "release: deploy ${{ github.ref_name }}"
+            git push origin "$PAGES_BRANCH"
+          fi
+
+          # Cleanup worktree
+          cd -
+          git worktree remove "$WORK" --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ github.ref_name }}" dist/*.whl \
-            --title "${{ github.ref_name }}" \
+          gh release create "${{ github.ref_name }}" dist/*.whl dist/*.tar.gz \
+            --title "Guru ${{ github.ref_name }}" \
             --generate-notes
 
       - name: Deploy to GitHub Pages index

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           mkdir -p dist
           for pkg in packages/guru-core packages/guru-server packages/guru-mcp packages/guru-cli .; do
-            uv build --directory "$pkg" --out-dir dist/
+            uv build --directory "$pkg" --out-dir "$PWD/dist/"
           done
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,7 @@ jobs:
             git fetch origin "$PAGES_BRANCH"
             git worktree add "$WORK" "$PAGES_BRANCH"
           else
-            git worktree add --orphan "$WORK" "$PAGES_BRANCH"
-            # Clean the orphan worktree
-            rm -rf "$WORK"/*
+            git worktree add --orphan -b "$PAGES_BRANCH" "$WORK"
           fi
 
           # Copy new wheels

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ __pycache__/
 *.egg-info/
 dist/
 build/
-
+.worktrees/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,8 @@ make fmt                        # auto-fix + format
 
 - `mise.toml` manages Python and pre-commit versions (mise tool version manager)
 - `pre-commit install` to set up git hooks after cloning
+- Claude Code hooks (`.claude/settings.json`) auto-run `ruff check --fix` + `ruff format`
+  on every Python file after Edit/Write — no manual formatting needed
 
 ## Distribution
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,30 @@ uv run guru-server              # run server directly
 uv run guru-mcp                 # run MCP server (stdio)
 ```
 
+## Distribution
+
+Guru is distributed via a PEP 503 simple index on GitHub Pages.
+Build backend is `hatchling` + `uv-dynamic-versioning` (version from git tags).
+
+```bash
+uv tool install guru --extra-index-url https://martinmacak.github.io/guru/simple/
+```
+
+### Releasing
+
+```bash
+git tag v0.2.0
+git push --tags
+# CI builds wheels, creates GitHub Release, deploys to Pages index
+```
+
+### Build locally
+
+```bash
+uv build                                 # build root meta-package
+uv build --directory packages/guru-core  # build single package
+```
+
 ## Testing
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Do not add cross-dependencies that violate this graph.
 
 ## Tech Stack
 
+- hatchling + uv-dynamic-versioning (build backend, version from git tags)
 - FastAPI + uvicorn (server)
 - LanceDB (vector storage)
 - Ollama + nomic-embed-text (embeddings)
@@ -77,7 +78,26 @@ uv sync --all-packages          # install all workspace packages
 uv run guru                     # run CLI (launches TUI with no args)
 uv run guru-server              # run server directly
 uv run guru-mcp                 # run MCP server (stdio)
+make help                       # list all available targets
+make test                       # unit + integration tests (fast)
+make test-all                   # unit + integration + e2e tests
+make build                      # build all 5 wheels into dist/
+make lint                       # check code style
+make fmt                        # auto-fix + format
 ```
+
+## Code Quality
+
+- Ruff is the linter and formatter. Config is in root `pyproject.toml`.
+- `make lint` — check only (ruff check + ruff format --check)
+- `make fmt` or `make format` — auto-fix + format (matches pre-commit)
+- pre-commit hooks run ruff on every commit. Run `make format` before committing.
+- Ruff rules: E, W, F, I, UP, B, SIM, RUF. Line length 99.
+
+## Tooling
+
+- `mise.toml` manages Python and pre-commit versions (mise tool version manager)
+- `pre-commit install` to set up git hooks after cloning
 
 ## Distribution
 
@@ -134,6 +154,7 @@ uv run behave tests/e2e/features/        # run BDD e2e tests (serial)
 ## CI (GitHub Actions)
 
 - `ci.yml` — unit tests per-package (skip if unchanged), e2e behind `require-e2e-tests` label
+- `release.yml` — builds and publishes wheels on tag push, deploys to GitHub Pages index
 - `claude-code-review.yml` — Claude review behind `require-claude-review` label
 - `claude.yml` — @claude mentions in PR comments
 
@@ -163,3 +184,11 @@ All design documents live under `docs/`, organized by type:
   The MCP protocol layer (Client -> FastMCP -> CallToolRequest) is fully exercised.
 - behave features run one server per feature (via `before_feature` hook) — features
   are fully independent and safe to parallelize.
+- `uv_build` does not support dynamic versioning (astral-sh/uv#14946). Use `hatchling`.
+- `uv-dynamic-versioning` requires `hatchling`, not `uv_build` as build backend.
+- When `"dependencies"` is in `dynamic = [...]`, ALL deps (inter-package + external)
+  must go in `[tool.hatch.metadata.hooks.uv-dynamic-versioning]`, not `[project]`.
+- `uv build --directory <pkg> --out-dir dist/` resolves `dist/` relative to the
+  package dir, not cwd. Use absolute paths: `--out-dir "$(pwd)/dist/"`.
+- pre-commit uses its own ruff install (from the hook repo), not the project's.
+  The hook's ruff version may differ — keep `.pre-commit-config.yaml` rev in sync.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to Guru
+
+## Development setup
+
+```bash
+git clone https://github.com/martinmacak/guru.git
+cd guru
+uv sync --all-packages
+```
+
+## Running tests
+
+```bash
+uv run pytest                            # unit + integration tests
+uv run pytest packages/guru-core/        # guru-core tests only
+uv run pytest packages/guru-server/      # guru-server tests only
+uv run pytest packages/guru-mcp/         # guru-mcp tests only
+uv run pytest packages/guru-cli/         # guru-cli tests only
+uv run pytest -n auto                    # parallel (opt-in)
+uv run behave tests/e2e/features/        # BDD e2e tests
+./scripts/run-behave-parallel.sh         # e2e tests in parallel
+```
+
+## Project structure
+
+```
+packages/
+  guru-core/     shared client SDK (types, discovery, auto-start, HTTP client)
+  guru-server/   FastAPI daemon (LanceDB, Ollama, ingestion, REST API)
+  guru-mcp/      MCP protocol adapter (FastMCP, stdio)
+  guru-cli/      CLI (click) + TUI (Textual)
+```
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full architecture constitution.
+
+## Package dependencies
+
+```
+guru (meta-package)
+├── guru-core     (pydantic, httpx)
+├── guru-server   (guru-core, fastapi, lancedb, llama-index, ollama)
+├── guru-mcp      (guru-core, fastmcp)
+└── guru-cli      (guru-core, click, textual)
+```
+
+## Releasing
+
+Releases are automated via CI. To publish a new version:
+
+```bash
+git tag v0.2.0
+git push --tags
+```
+
+CI will build all wheels, create a GitHub Release, and deploy to the
+GitHub Pages package index automatically.
+
+## CI
+
+- `ci.yml` — unit tests per-package (skip if unchanged), e2e behind `require-e2e-tests` label
+- `release.yml` — builds and publishes on tag push
+- `claude-code-review.yml` — Claude review behind `require-claude-review` label

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,9 @@ help:
 	@echo "  build-index        Build wheels then generate PEP 503 index into dist/simple/"
 	@echo ""
 	@echo "Code quality"
-	@echo "  lint               Check code style (not configured yet)"
-	@echo "  fmt                Format code (not configured yet)"
+	@echo "  lint               Check code style (ruff check)"
+	@echo "  fmt                Auto-fix lint issues and format code"
+	@echo "  format             Alias for fmt"
 	@echo ""
 	@echo "Maintenance"
 	@echo "  clean              Remove dist/, build/, caches, and egg-info directories"
@@ -81,11 +82,13 @@ build-index: build
 
 .PHONY: lint
 lint:
-	@echo "Linting is not configured yet. Add ruff or flake8 to get started."
+	uv run ruff check .
+	uv run ruff format --check .
 
-.PHONY: fmt
-fmt:
-	@echo "Formatting is not configured yet. Add ruff format or black to get started."
+.PHONY: fmt format
+fmt format:
+	uv run ruff check --fix .
+	uv run ruff format .
 
 # ─── Maintenance ─────────────────────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,9 @@ test-all: test-unit test-integration test-e2e
 
 .PHONY: build
 build:
-	uv build
-	@for pkg in $(PACKAGES); do \
-		uv build --directory $$pkg; \
+	@mkdir -p dist
+	@for pkg in $(PACKAGES) .; do \
+		uv build --directory $$pkg --out-dir "$$(pwd)/dist/"; \
 	done
 	@echo "All wheels written to dist/"
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,98 @@
+.DEFAULT_GOAL := help
+
+PACKAGES := packages/guru-core packages/guru-server packages/guru-mcp packages/guru-cli
+
+# ─── Help ────────────────────────────────────────────────────────────────────
+
+.PHONY: help
+help:
+	@echo "Guru — local-first knowledge-base manager"
+	@echo ""
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "Setup"
+	@echo "  install            Install all workspace packages (uv sync --all-packages)"
+	@echo ""
+	@echo "Testing"
+	@echo "  test               Unit + integration tests (fast, no e2e)"
+	@echo "  test-unit          Unit tests across all packages"
+	@echo "  test-integration   Integration tests (tests/)"
+	@echo "  test-e2e           BDD e2e tests (serial)"
+	@echo "  test-e2e-parallel  BDD e2e tests (parallel, one process per feature)"
+	@echo "  test-all           All tests: unit + integration + e2e"
+	@echo ""
+	@echo "Build"
+	@echo "  build              Build all 5 wheels into dist/"
+	@echo "  build-index        Build wheels then generate PEP 503 index into dist/simple/"
+	@echo ""
+	@echo "Code quality"
+	@echo "  lint               Check code style (not configured yet)"
+	@echo "  fmt                Format code (not configured yet)"
+	@echo ""
+	@echo "Maintenance"
+	@echo "  clean              Remove dist/, build/, caches, and egg-info directories"
+
+# ─── Setup ───────────────────────────────────────────────────────────────────
+
+.PHONY: install
+install:
+	uv sync --all-packages
+
+# ─── Testing ─────────────────────────────────────────────────────────────────
+
+.PHONY: test-unit
+test-unit:
+	uv run pytest packages/ -v --tb=short
+
+.PHONY: test-integration
+test-integration:
+	uv run pytest tests/ -v --tb=short
+
+.PHONY: test-e2e
+test-e2e:
+	uv run behave tests/e2e/features/
+
+.PHONY: test-e2e-parallel
+test-e2e-parallel:
+	./scripts/run-behave-parallel.sh
+
+.PHONY: test
+test: test-unit test-integration
+
+.PHONY: test-all
+test-all: test-unit test-integration test-e2e
+
+# ─── Build ───────────────────────────────────────────────────────────────────
+
+.PHONY: build
+build:
+	uv build
+	@for pkg in $(PACKAGES); do \
+		uv build --directory $$pkg; \
+	done
+	@echo "All wheels written to dist/"
+
+.PHONY: build-index
+build-index: build
+	uv run python scripts/generate_index.py dist/ dist/simple/
+	@echo "PEP 503 index written to dist/simple/"
+
+# ─── Code quality ────────────────────────────────────────────────────────────
+
+.PHONY: lint
+lint:
+	@echo "Linting is not configured yet. Add ruff or flake8 to get started."
+
+.PHONY: fmt
+fmt:
+	@echo "Formatting is not configured yet. Add ruff format or black to get started."
+
+# ─── Maintenance ─────────────────────────────────────────────────────────────
+
+.PHONY: clean
+clean:
+	rm -rf dist/ build/
+	find . -type d -name __pycache__ -not -path './.git/*' -exec rm -rf {} +
+	find . -type d -name '*.egg-info' -not -path './.git/*' -exec rm -rf {} +
+	find . -type d -name .pytest_cache -not -path './.git/*' -exec rm -rf {} +
+	@echo "Clean complete."

--- a/README.md
+++ b/README.md
@@ -1,69 +1,66 @@
 # Guru
 
-A local-first knowledge-base manager that indexes markdown documents in a git repo and serves them to AI agents via RAG over MCP. Runs entirely on your MacBook with no cloud dependencies.
-
-## What it does
-
-- Indexes markdown files with YAML frontmatter into a vector database (LanceDB)
-- Embeds content using Ollama (nomic-embed-text) running locally
-- Serves knowledge to AI agents via MCP (Model Context Protocol)
-- Provides a CLI for indexing, searching, and retrieving documents
-- Rule-based configuration for labeling and organizing documents
-
-## Architecture
-
-```
-AI Agent (Claude Code / Cursor / Continue.dev)
-    | stdio
-guru-mcp (MCP protocol adapter)
-    | HTTP-over-UDS
-guru-server (FastAPI daemon)
-    |-- LanceDB (embedded vector storage)
-    |-- Ollama (nomic-embed-text embeddings)
-
-Developer terminal
-    |
-guru-cli (click commands / Textual TUI)
-    | HTTP-over-UDS
-guru-server
-```
-
-All state is owned by `guru-server`. Clients (`guru-mcp`, `guru-cli`) connect via HTTP over Unix domain sockets through the shared `guru-core` SDK.
+A local-first knowledge-base manager that indexes markdown documents in a git repo and serves them to AI agents via RAG over MCP. Runs entirely on your machine with no cloud dependencies.
 
 ## Prerequisites
 
 - Python >= 3.13
 - [uv](https://docs.astral.sh/uv/) (package manager)
-- [Ollama](https://ollama.com) with `nomic-embed-text` model
+- [Ollama](https://ollama.com) with the `nomic-embed-text` model
 
 ```bash
+# macOS
 brew install ollama
+
+# Linux — see https://ollama.com/download
+curl -fsSL https://ollama.com/install.sh | sh
+
+# Pull the embedding model
 ollama pull nomic-embed-text
 ```
+
+## Install
+
+```bash
+uv tool install guru --extra-index-url https://martinmacak.github.io/guru/simple/
+```
+
+This installs the `guru`, `guru-server`, and `guru-mcp` commands.
 
 ## Quick start
 
 ```bash
-# Install
-uv sync --all-packages
-
-# Initialize a project
+# Initialize guru in your markdown repo
 cd /path/to/your/repo
-uv run guru init
+guru init
 
-# Index your markdown files
-uv run guru index
+# Index your documents
+guru index
 
 # Search
-uv run guru search "authentication flow"
-
-# List indexed documents
-uv run guru list
+guru search "authentication flow"
 ```
+
+`guru init` creates:
+- `.guru/` — runtime directory (gitignored automatically)
+- `guru.json` — indexing rules (version-controlled)
+- `.mcp.json` — MCP server configuration for AI agents
+
+## MCP integration
+
+After `guru init`, your `.mcp.json` is configured automatically. AI agents that support MCP (Claude Code, Cursor, Continue.dev) will discover the guru tools:
+
+- `search` — semantic search across your knowledge base
+- `get_document` — retrieve a full document
+- `list_documents` — browse all indexed documents
+- `get_section` — retrieve a specific markdown section
+- `index_status` — check index health and stats
+
+The guru server starts automatically when an MCP tool is first invoked.
 
 ## Configuration
 
-Create `guru.json` in your project root (or let `guru init` create defaults):
+Edit `guru.json` in your project root to control indexing:
 
 ```json
 [
@@ -85,56 +82,50 @@ Create `guru.json` in your project root (or let `guru init` create defaults):
 ]
 ```
 
-Config resolution: `./guru.json` > `./.guru/config.json` > `~/.config/guru/config.json`. Rules merge by `ruleName` (local replaces global, new names appended).
-
-## MCP integration
-
-Add to your `.mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "guru": {
-      "command": "uv",
-      "args": ["run", "guru-mcp"]
-    }
-  }
-}
-```
-
-Available MCP tools: `search`, `get_document`, `list_documents`, `get_section`, `index_status`.
+Config resolution: `./guru.json` > `./.guru/config.json` > `~/.config/guru/config.json`. Rules merge by `ruleName` (local overrides global).
 
 ## CLI commands
 
 ```
-guru                     # launch TUI (Phase 3)
-guru init                # initialize .guru/ in current directory
+guru init                # set up guru in current directory
 guru index [PATH]        # index documents
 guru search "query"      # semantic search
 guru doc <path>          # get full document
 guru doc <path> -s "H"   # get specific section
-guru list                # list all indexed documents
+guru list                # list indexed documents
 guru config              # show resolved config
 guru server start|stop|status
 ```
 
-## Development
+## Upgrade
 
 ```bash
-uv sync --all-packages              # install everything
-uv run pytest                       # unit + integration tests
-uv run behave tests/e2e/features/   # BDD e2e tests
-./scripts/run-behave-parallel.sh    # e2e tests in parallel
+uv tool upgrade guru --extra-index-url https://martinmacak.github.io/guru/simple/
 ```
 
-## Project structure
+## Uninstall
 
+```bash
+uv tool uninstall guru
 ```
-packages/
-  guru-core/     shared client SDK (types, discovery, auto-start, HTTP client)
-  guru-server/   FastAPI daemon (LanceDB, Ollama, ingestion, REST API)
-  guru-mcp/      MCP protocol adapter (FastMCP, stdio)
-  guru-cli/      CLI (click) + TUI (Textual)
-```
+
+## Troubleshooting
+
+**"guru-server did not start"**
+- Check that Ollama is running: `ollama list`
+- Ensure the embedding model is installed: `ollama pull nomic-embed-text`
+
+**"command not found: guru"**
+- Ensure `~/.local/bin` is on your PATH (uv tool install puts binaries there)
+- Run `uv tool list` to verify guru is installed
+
+**Server won't stop**
+- Run `guru server stop` or check `.guru/guru.pid` for the process ID
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and release process.
+
+## Architecture
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the full architecture constitution.

--- a/docs/superpowers/plans/2026-04-09-packaging-distribution.md
+++ b/docs/superpowers/plans/2026-04-09-packaging-distribution.md
@@ -1,0 +1,1314 @@
+# Packaging & Distribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Distribute Guru as a `uv tool install`-able package via a PEP 503 simple index on GitHub Pages, with automatic versioning from git tags.
+
+**Architecture:** Switch all 5 packages from `uv_build` to `hatchling` + `uv-dynamic-versioning` for git-tag-based lockstep versioning. Root `guru` becomes a meta-package pulling in all sub-packages. A CI workflow builds wheels on tag push and deploys to a GitHub Pages simple index. `guru init` is enhanced to generate `.mcp.json` and `.gitignore` entries.
+
+**Tech Stack:** hatchling, uv-dynamic-versioning (dunamai), GitHub Actions, GitHub Pages, PEP 503
+
+**Spec:** `docs/superpowers/specs/2026-04-09-packaging-distribution-design.md`
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `pyproject.toml` | Modify | Meta-package with hatchling, dynamic version + deps |
+| `packages/guru-core/pyproject.toml` | Modify | Switch to hatchling, dynamic version |
+| `packages/guru-server/pyproject.toml` | Modify | Switch to hatchling, dynamic version + deps |
+| `packages/guru-mcp/pyproject.toml` | Modify | Switch to hatchling, dynamic version + deps |
+| `packages/guru-cli/pyproject.toml` | Modify | Switch to hatchling, dynamic version + deps |
+| `packages/guru-cli/src/guru_cli/cli.py` | Modify | Enhance `init` cmd, fix version |
+| `packages/guru-cli/tests/test_cli.py` | Modify | Tests for new init behavior |
+| `scripts/generate-index.py` | Create | PEP 503 index HTML generator |
+| `scripts/test-generate-index.py` | Create | Tests for index generator |
+| `.github/workflows/release.yml` | Create | Tag-triggered release pipeline |
+| `README.md` | Rewrite | User-facing install/usage guide |
+| `CONTRIBUTING.md` | Create | Developer guide |
+
+---
+
+### Task 1: Switch guru-core to hatchling + dynamic versioning
+
+**Files:**
+- Modify: `packages/guru-core/pyproject.toml`
+
+This is the leaf dependency — no inter-package deps, simplest to start with.
+
+- [ ] **Step 1: Update guru-core pyproject.toml**
+
+Replace the entire `packages/guru-core/pyproject.toml` with:
+
+```toml
+[project]
+name = "guru-core"
+dynamic = ["version"]
+description = "Guru shared client SDK and types"
+requires-python = ">=3.13"
+dependencies = [
+    "pydantic>=2.0",
+    "httpx>=0.28",
+]
+
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["src"]
+```
+
+Key changes: removed `version = "0.1.0"`, added `dynamic = ["version"]`, switched build-system from `uv_build` to `hatchling` + `uv-dynamic-versioning`, added hatch version source and dynamic versioning config. Dependencies stay in `[project]` because guru-core has no inter-package deps.
+
+- [ ] **Step 2: Verify the workspace still resolves**
+
+Run: `uv sync --all-packages`
+Expected: completes successfully, all packages install
+
+- [ ] **Step 3: Run guru-core tests**
+
+Run: `uv run pytest packages/guru-core/ -v --tb=short`
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/guru-core/pyproject.toml
+git commit -m "build: switch guru-core to hatchling + uv-dynamic-versioning"
+```
+
+---
+
+### Task 2: Switch guru-server to hatchling + dynamic versioning
+
+**Files:**
+- Modify: `packages/guru-server/pyproject.toml`
+
+guru-server depends on guru-core, so it needs `dynamic = ["version", "dependencies"]` and the metadata hook for version-pinned deps.
+
+- [ ] **Step 1: Update guru-server pyproject.toml**
+
+Replace the entire `packages/guru-server/pyproject.toml` with:
+
+```toml
+[project]
+name = "guru-server"
+dynamic = ["version", "dependencies"]
+description = "Guru FastAPI server — owns all state (LanceDB, Ollama, ingestion)"
+readme = "README.md"
+authors = [
+    { name = "Martin Macak", email = "martin.macak@gmail.com" }
+]
+requires-python = ">=3.13"
+
+[project.scripts]
+guru-server = "guru_server.main:main"
+
+[tool.uv.sources]
+guru-core = { workspace = true }
+
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.hatch.metadata.hooks.uv-dynamic-versioning]
+dependencies = [
+    "guru-core=={{ version }}",
+    "httpx>=0.28",
+    "pydantic>=2.0",
+    "llama-index-core>=0.14",
+    "python-frontmatter>=1.1",
+    "lancedb>=0.27",
+    "pandas>=2.0",
+    "fastapi>=0.115",
+    "uvicorn>=0.34",
+]
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "httpx>=0.28",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["src"]
+```
+
+Key changes: removed `version` and `dependencies` from `[project]`, added both to `dynamic`, moved all dependencies (including `guru-core=={{ version }}`) into the metadata hook, switched build backend.
+
+- [ ] **Step 2: Verify the workspace still resolves**
+
+Run: `uv sync --all-packages`
+Expected: completes successfully
+
+- [ ] **Step 3: Run guru-server tests**
+
+Run: `uv run pytest packages/guru-server/ -v --tb=short`
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/guru-server/pyproject.toml
+git commit -m "build: switch guru-server to hatchling + uv-dynamic-versioning"
+```
+
+---
+
+### Task 3: Switch guru-mcp to hatchling + dynamic versioning
+
+**Files:**
+- Modify: `packages/guru-mcp/pyproject.toml`
+
+- [ ] **Step 1: Update guru-mcp pyproject.toml**
+
+Replace the entire `packages/guru-mcp/pyproject.toml` with:
+
+```toml
+[project]
+name = "guru-mcp"
+dynamic = ["version", "dependencies"]
+description = "Guru MCP protocol adapter"
+readme = "README.md"
+authors = [
+    { name = "Martin Macak", email = "martin.macak@gmail.com" }
+]
+requires-python = ">=3.13"
+
+[project.scripts]
+guru-mcp = "guru_mcp.server:main"
+
+[tool.uv.sources]
+guru-core = { workspace = true }
+
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.hatch.metadata.hooks.uv-dynamic-versioning]
+dependencies = [
+    "guru-core=={{ version }}",
+    "fastmcp>=2.0",
+]
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["src"]
+```
+
+- [ ] **Step 2: Verify the workspace still resolves**
+
+Run: `uv sync --all-packages`
+Expected: completes successfully
+
+- [ ] **Step 3: Run guru-mcp tests**
+
+Run: `uv run pytest packages/guru-mcp/ -v --tb=short`
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/guru-mcp/pyproject.toml
+git commit -m "build: switch guru-mcp to hatchling + uv-dynamic-versioning"
+```
+
+---
+
+### Task 4: Switch guru-cli to hatchling + dynamic versioning
+
+**Files:**
+- Modify: `packages/guru-cli/pyproject.toml`
+- Modify: `packages/guru-cli/src/guru_cli/cli.py` (fix hardcoded version)
+- Modify: `packages/guru-cli/tests/test_cli.py` (fix version test)
+
+- [ ] **Step 1: Update guru-cli pyproject.toml**
+
+Replace the entire `packages/guru-cli/pyproject.toml` with:
+
+```toml
+[project]
+name = "guru-cli"
+dynamic = ["version", "dependencies"]
+description = "Guru CLI and TUI"
+readme = "README.md"
+authors = [
+    { name = "Martin Macak", email = "martin.macak@gmail.com" }
+]
+requires-python = ">=3.13"
+
+[project.scripts]
+guru = "guru_cli.cli:cli"
+
+[tool.uv.sources]
+guru-core = { workspace = true }
+
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.hatch.metadata.hooks.uv-dynamic-versioning]
+dependencies = [
+    "guru-core=={{ version }}",
+    "click>=8.1",
+    "textual>=0.80",
+]
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-asyncio>=0.24",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["src"]
+```
+
+- [ ] **Step 2: Fix hardcoded version in cli.py**
+
+In `packages/guru-cli/src/guru_cli/cli.py`, replace the hardcoded version:
+
+```python
+# Before:
+@click.version_option(version="0.1.0")
+
+# After:
+from importlib.metadata import version as pkg_version
+
+@click.version_option(version=pkg_version("guru-cli"))
+```
+
+The `importlib.metadata.version()` reads the version from the installed package metadata, which is set by hatchling + uv-dynamic-versioning at build time.
+
+Note: the import should go at the top of the file with the other imports. The `@click.version_option` decorator evaluates `pkg_version("guru-cli")` at import time, which is fine for a CLI entry point.
+
+Full change to the top of `cli.py`:
+
+```python
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from importlib.metadata import version as pkg_version
+from pathlib import Path
+
+import click
+
+from guru_core.discovery import find_guru_root, GuruNotFoundError
+from guru_core.autostart import ensure_server
+from guru_core.client import GuruClient
+```
+
+And the decorator:
+
+```python
+@click.group(invoke_without_command=True)
+@click.version_option(version=pkg_version("guru-cli"))
+@click.pass_context
+def cli(ctx):
+```
+
+- [ ] **Step 3: Fix the version test**
+
+In `packages/guru-cli/tests/test_cli.py`, the test `test_cli_version` checks for `"0.1.0"`. Update it to verify the command succeeds and outputs *some* version rather than a hardcoded string:
+
+```python
+def test_cli_version(runner):
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert "version" in result.output.lower() or "." in result.output
+```
+
+- [ ] **Step 4: Verify workspace resolves and tests pass**
+
+Run: `uv sync --all-packages && uv run pytest packages/guru-cli/ -v --tb=short`
+Expected: all tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/guru-cli/pyproject.toml packages/guru-cli/src/guru_cli/cli.py packages/guru-cli/tests/test_cli.py
+git commit -m "build: switch guru-cli to hatchling + uv-dynamic-versioning
+
+Also replace hardcoded version string with importlib.metadata lookup."
+```
+
+---
+
+### Task 5: Convert root pyproject.toml to meta-package
+
+**Files:**
+- Modify: `pyproject.toml`
+
+The root package becomes a meta-package that pulls in all sub-packages.
+
+- [ ] **Step 1: Update root pyproject.toml**
+
+Replace the entire `pyproject.toml` with:
+
+```toml
+[project]
+name = "guru"
+dynamic = ["version", "dependencies"]
+description = "Local-first knowledge base manager with MCP interface"
+requires-python = ">=3.13"
+
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.hatch.metadata.hooks.uv-dynamic-versioning]
+dependencies = [
+    "guru-core=={{ version }}",
+    "guru-server=={{ version }}",
+    "guru-mcp=={{ version }}",
+    "guru-cli=={{ version }}",
+]
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
+
+[tool.uv.workspace]
+members = ["packages/*"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+addopts = "--import-mode=importlib -m 'not slow'"
+markers = [
+    "slow: end-to-end tests that start a real server (deselected by default, run with: -m slow)",
+]
+
+[dependency-groups]
+dev = [
+    "behave>=1.3.3",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "pytest-xdist>=3.8.0",
+]
+```
+
+Key changes: removed `version` and `dependencies` from `[project]`, added `dynamic`, added hatchling build-system, added metadata hook with all 4 sub-packages as `{{ version }}`-pinned deps. Preserved `[tool.uv.workspace]`, `[tool.pytest.ini_options]`, and `[dependency-groups]`.
+
+- [ ] **Step 2: Verify full workspace resolves**
+
+Run: `uv sync --all-packages`
+Expected: completes successfully
+
+- [ ] **Step 3: Run all tests**
+
+Run: `uv run pytest -v --tb=short`
+Expected: all tests pass
+
+- [ ] **Step 4: Verify wheel builds**
+
+Run: `uv build`
+Expected: produces `dist/guru-*.whl` and `dist/guru-*.tar.gz`. The version will be derived from the latest git tag (or a dev version if no tag exists yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "build: convert root package to meta-package with dynamic versioning"
+```
+
+---
+
+### Task 6: Enhance `guru init` — add .mcp.json generation
+
+**Files:**
+- Modify: `packages/guru-cli/src/guru_cli/cli.py`
+- Modify: `packages/guru-cli/tests/test_cli.py`
+
+- [ ] **Step 1: Write failing tests for .mcp.json generation**
+
+Add these tests to `packages/guru-cli/tests/test_cli.py`:
+
+```python
+def test_init_creates_mcp_json(runner, tmp_path):
+    """guru init creates .mcp.json with guru entry when file doesn't exist."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        mcp_file = Path(td) / ".mcp.json"
+        assert mcp_file.is_file()
+        mcp = json.loads(mcp_file.read_text())
+        assert mcp["mcpServers"]["guru"]["command"] == "guru-mcp"
+        assert "Added guru to .mcp.json" in result.output
+
+
+def test_init_merges_into_existing_mcp_json(runner, tmp_path):
+    """guru init preserves existing MCP servers when adding guru."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        mcp_file = Path(td) / ".mcp.json"
+        mcp_file.write_text(json.dumps({
+            "mcpServers": {
+                "other-tool": {"command": "other-tool-mcp"}
+            }
+        }))
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        mcp = json.loads(mcp_file.read_text())
+        assert "other-tool" in mcp["mcpServers"]
+        assert "guru" in mcp["mcpServers"]
+
+
+def test_init_skips_existing_guru_mcp_entry(runner, tmp_path):
+    """guru init skips .mcp.json if guru entry already exists."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        mcp_file = Path(td) / ".mcp.json"
+        mcp_file.write_text(json.dumps({
+            "mcpServers": {
+                "guru": {"command": "guru-mcp"}
+            }
+        }))
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        assert "guru already configured in .mcp.json" in result.output
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest packages/guru-cli/tests/test_cli.py::test_init_creates_mcp_json packages/guru-cli/tests/test_cli.py::test_init_merges_into_existing_mcp_json packages/guru-cli/tests/test_cli.py::test_init_skips_existing_guru_mcp_entry -v`
+Expected: FAIL (new behavior not implemented)
+
+- [ ] **Step 3: Implement .mcp.json generation in init command**
+
+In `packages/guru-cli/src/guru_cli/cli.py`, replace the `init` function with:
+
+```python
+@cli.command()
+def init():
+    """Initialize a guru project in the current directory."""
+    cwd = Path.cwd()
+    guru_dir = cwd / ".guru"
+    guru_json = cwd / "guru.json"
+    mcp_json = cwd / ".mcp.json"
+    gitignore = cwd / ".gitignore"
+
+    # 1. Create .guru/ directory
+    if guru_dir.is_dir():
+        click.echo("Already initialized — .guru/ directory exists.")
+    else:
+        guru_dir.mkdir()
+        (guru_dir / "db").mkdir()
+        click.echo("Created .guru/")
+
+    # 2. Create guru.json
+    if guru_json.exists():
+        click.echo("guru.json already exists, skipping.")
+    else:
+        guru_json.write_text(json.dumps(DEFAULT_CONFIG, indent=2) + "\n")
+        click.echo("Created guru.json with default rules")
+
+    # 3. Merge guru into .mcp.json
+    _init_mcp_json(mcp_json)
+
+    # 4. Add .guru/ to .gitignore
+    _init_gitignore(gitignore)
+
+
+def _init_mcp_json(mcp_json: Path) -> None:
+    """Add guru entry to .mcp.json, creating or merging as needed."""
+    guru_entry = {"command": "guru-mcp"}
+
+    if mcp_json.exists():
+        mcp = json.loads(mcp_json.read_text())
+        servers = mcp.setdefault("mcpServers", {})
+        if "guru" in servers:
+            click.echo("guru already configured in .mcp.json, skipping.")
+            return
+        servers["guru"] = guru_entry
+    else:
+        mcp = {"mcpServers": {"guru": guru_entry}}
+
+    mcp_json.write_text(json.dumps(mcp, indent=2) + "\n")
+    click.echo("Added guru to .mcp.json")
+
+
+def _init_gitignore(gitignore: Path) -> None:
+    """Add .guru/ to .gitignore if not already present."""
+    marker = ".guru/"
+    if gitignore.exists():
+        content = gitignore.read_text()
+        if marker in content.splitlines():
+            click.echo(".guru/ already in .gitignore, skipping.")
+            return
+        if not content.endswith("\n"):
+            content += "\n"
+        content += marker + "\n"
+    else:
+        content = marker + "\n"
+
+    gitignore.write_text(content)
+    click.echo("Added .guru/ to .gitignore")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest packages/guru-cli/tests/test_cli.py -v --tb=short`
+Expected: all tests pass (including the existing ones)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/guru-cli/src/guru_cli/cli.py packages/guru-cli/tests/test_cli.py
+git commit -m "feat: guru init generates .mcp.json and .gitignore entries"
+```
+
+---
+
+### Task 7: Enhance `guru init` — add .gitignore generation
+
+**Files:**
+- Modify: `packages/guru-cli/tests/test_cli.py`
+
+The implementation was included in Task 6. This task adds the tests.
+
+- [ ] **Step 1: Write tests for .gitignore generation**
+
+Add these tests to `packages/guru-cli/tests/test_cli.py`:
+
+```python
+def test_init_creates_gitignore(runner, tmp_path):
+    """guru init creates .gitignore with .guru/ when file doesn't exist."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        gitignore = Path(td) / ".gitignore"
+        assert gitignore.is_file()
+        assert ".guru/" in gitignore.read_text().splitlines()
+        assert "Added .guru/ to .gitignore" in result.output
+
+
+def test_init_appends_to_existing_gitignore(runner, tmp_path):
+    """guru init appends .guru/ to existing .gitignore."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        gitignore = Path(td) / ".gitignore"
+        gitignore.write_text("node_modules/\n.env\n")
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        lines = gitignore.read_text().splitlines()
+        assert "node_modules/" in lines
+        assert ".env" in lines
+        assert ".guru/" in lines
+
+
+def test_init_skips_existing_gitignore_entry(runner, tmp_path):
+    """guru init skips .gitignore if .guru/ already present."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        gitignore = Path(td) / ".gitignore"
+        gitignore.write_text(".guru/\n")
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        assert ".guru/ already in .gitignore" in result.output
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `uv run pytest packages/guru-cli/tests/test_cli.py -v --tb=short`
+Expected: all tests pass (implementation was done in Task 6)
+
+- [ ] **Step 3: Update the existing init tests for new output format**
+
+The existing `test_init_creates_guru_dir` test checks for `"Initialized"` in output. The new `init` outputs line-by-line messages instead. Update:
+
+```python
+def test_init_creates_guru_dir(runner, tmp_path):
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        assert (Path(td) / ".guru").is_dir()
+        assert "Created .guru/" in result.output
+```
+
+The existing `test_init_already_initialized` test should still work because the `.guru/` check still outputs "already initialized". But verify it still passes.
+
+- [ ] **Step 4: Run all cli tests**
+
+Run: `uv run pytest packages/guru-cli/tests/test_cli.py -v --tb=short`
+Expected: all tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/guru-cli/tests/test_cli.py
+git commit -m "test: add tests for guru init .mcp.json and .gitignore generation"
+```
+
+---
+
+### Task 8: Create PEP 503 index generator script
+
+**Files:**
+- Create: `scripts/generate-index.py`
+- Create: `scripts/test-generate-index.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/test-generate-index.py`:
+
+```python
+"""Tests for the PEP 503 simple index generator."""
+
+import sys
+from pathlib import Path
+
+# Allow importing the script from the same directory
+sys.path.insert(0, str(Path(__file__).parent))
+
+import pytest
+from generate_index import generate_index
+
+
+@pytest.fixture
+def wheel_dir(tmp_path):
+    """Create a fake wheels directory with sample wheel files."""
+    wheels = tmp_path / "wheels"
+    wheels.mkdir()
+    # Create fake wheel files (content doesn't matter, just filenames)
+    (wheels / "guru-0.1.0-py3-none-any.whl").touch()
+    (wheels / "guru_core-0.1.0-py3-none-any.whl").touch()
+    (wheels / "guru_server-0.1.0-py3-none-any.whl").touch()
+    (wheels / "guru_mcp-0.1.0-py3-none-any.whl").touch()
+    (wheels / "guru_cli-0.1.0-py3-none-any.whl").touch()
+    return wheels
+
+
+def test_generates_root_index(wheel_dir, tmp_path):
+    simple = tmp_path / "simple"
+    generate_index(wheel_dir, simple)
+    root_html = (simple / "index.html").read_text()
+    assert "<a href=\"guru/\">guru</a>" in root_html
+    assert "<a href=\"guru-core/\">guru-core</a>" in root_html
+    assert "<a href=\"guru-server/\">guru-server</a>" in root_html
+    assert "<a href=\"guru-mcp/\">guru-mcp</a>" in root_html
+    assert "<a href=\"guru-cli/\">guru-cli</a>" in root_html
+
+
+def test_generates_package_index(wheel_dir, tmp_path):
+    simple = tmp_path / "simple"
+    generate_index(wheel_dir, simple)
+    guru_html = (simple / "guru" / "index.html").read_text()
+    assert "guru-0.1.0-py3-none-any.whl" in guru_html
+    # Check the href points to the wheels directory
+    assert "../../wheels/guru-0.1.0-py3-none-any.whl" in guru_html
+
+
+def test_multiple_versions(wheel_dir, tmp_path):
+    (wheel_dir / "guru-0.2.0-py3-none-any.whl").touch()
+    simple = tmp_path / "simple"
+    generate_index(wheel_dir, simple)
+    guru_html = (simple / "guru" / "index.html").read_text()
+    assert "guru-0.1.0-py3-none-any.whl" in guru_html
+    assert "guru-0.2.0-py3-none-any.whl" in guru_html
+
+
+def test_normalized_package_names(wheel_dir, tmp_path):
+    """Wheel filenames use underscores but PEP 503 dirs use hyphens."""
+    simple = tmp_path / "simple"
+    generate_index(wheel_dir, simple)
+    # guru_core wheel → guru-core directory
+    assert (simple / "guru-core" / "index.html").is_file()
+    core_html = (simple / "guru-core" / "index.html").read_text()
+    assert "guru_core-0.1.0-py3-none-any.whl" in core_html
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest scripts/test-generate-index.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'generate_index'`
+
+- [ ] **Step 3: Implement the index generator**
+
+Create `scripts/generate-index.py`:
+
+```python
+#!/usr/bin/env python3
+"""Generate a PEP 503 simple repository index from a directory of wheels.
+
+Usage: python scripts/generate-index.py <wheels-dir> <output-dir>
+
+Scans <wheels-dir> for .whl files and generates a PEP 503-compliant simple
+repository index in <output-dir>/. Package directories use normalized names
+(lowercase, hyphens). Links point to ../../wheels/<filename>.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# PEP 503: normalize by lowercasing and replacing runs of [_.-] with a single hyphen
+_NORMALIZE_RE = re.compile(r"[-_.]+")
+
+
+def _normalize(name: str) -> str:
+    return _NORMALIZE_RE.sub("-", name).lower()
+
+
+def _parse_wheel_name(filename: str) -> str | None:
+    """Extract the distribution name from a wheel filename.
+
+    Wheel filenames follow: {name}-{version}(-{build})?-{python}-{abi}-{platform}.whl
+    """
+    parts = filename.split("-")
+    if len(parts) < 3:
+        return None
+    return parts[0]
+
+
+def generate_index(wheels_dir: Path, output_dir: Path) -> None:
+    """Generate PEP 503 simple index from wheels directory."""
+    wheel_files = sorted(wheels_dir.glob("*.whl"))
+
+    # Group wheels by normalized package name
+    packages: dict[str, list[str]] = {}
+    for whl in wheel_files:
+        raw_name = _parse_wheel_name(whl.name)
+        if raw_name is None:
+            continue
+        norm = _normalize(raw_name)
+        packages.setdefault(norm, []).append(whl.name)
+
+    # Generate root index
+    output_dir.mkdir(parents=True, exist_ok=True)
+    root_links = []
+    for name in sorted(packages):
+        root_links.append(f'<a href="{name}/">{name}</a>')
+
+    (output_dir / "index.html").write_text(
+        "<!DOCTYPE html>\n<html><body>\n"
+        + "\n".join(root_links)
+        + "\n</body></html>\n"
+    )
+
+    # Generate per-package index
+    for name, wheels in sorted(packages.items()):
+        pkg_dir = output_dir / name
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        links = []
+        for whl in sorted(wheels):
+            links.append(f'<a href="../../wheels/{whl}">{whl}</a>')
+        (pkg_dir / "index.html").write_text(
+            "<!DOCTYPE html>\n<html><body>\n"
+            + "\n".join(links)
+            + "\n</body></html>\n"
+        )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <wheels-dir> <output-dir>", file=sys.stderr)
+        sys.exit(1)
+    generate_index(Path(sys.argv[1]), Path(sys.argv[2]))
+    print(f"Index generated in {sys.argv[2]}")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest scripts/test-generate-index.py -v --tb=short`
+Expected: all 4 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/generate-index.py scripts/test-generate-index.py
+git commit -m "feat: add PEP 503 simple index generator script"
+```
+
+---
+
+### Task 9: Create GitHub Actions release workflow
+
+**Files:**
+- Create: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Create the release workflow**
+
+Create `.github/workflows/release.yml`:
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history needed for dunamai version detection
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install build dependencies
+        run: uv sync --all-packages
+
+      - name: Build all wheels
+        run: |
+          mkdir -p dist
+          for pkg in packages/guru-core packages/guru-server packages/guru-mcp packages/guru-cli .; do
+            uv build --directory "$pkg" --out-dir dist/
+          done
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" dist/*.whl \
+            --title "${{ github.ref_name }}" \
+            --generate-notes
+
+      - name: Deploy to GitHub Pages index
+        run: |
+          set -e
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Prepare a temporary working area
+          WORK=$(mktemp -d)
+          PAGES_BRANCH=gh-pages
+
+          # Try to fetch existing gh-pages, or start fresh
+          if git ls-remote --exit-code origin "$PAGES_BRANCH" > /dev/null 2>&1; then
+            git fetch origin "$PAGES_BRANCH"
+            git worktree add "$WORK" "$PAGES_BRANCH"
+          else
+            git worktree add --orphan "$WORK" "$PAGES_BRANCH"
+            # Clean the orphan worktree
+            rm -rf "$WORK"/*
+          fi
+
+          # Copy new wheels
+          mkdir -p "$WORK/wheels"
+          cp dist/*.whl "$WORK/wheels/"
+
+          # Generate index
+          python scripts/generate-index.py "$WORK/wheels" "$WORK/simple"
+
+          # Commit and push
+          cd "$WORK"
+          git add --all
+          if git diff --cached --quiet; then
+            echo "No changes to deploy"
+          else
+            git commit -m "release: deploy ${{ github.ref_name }}"
+            git push origin "$PAGES_BRANCH"
+          fi
+
+          # Cleanup worktree
+          cd -
+          git worktree remove "$WORK" --force
+```
+
+- [ ] **Step 2: Validate the YAML syntax**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))" 2>&1 || echo "Install PyYAML first: pip install pyyaml"`
+
+If `yaml` not available, use: `uv run python -c "import json, sys; print('YAML looks structurally valid')" && echo "Manual review: check indentation"`
+
+Alternatively, just review the file manually for correct YAML indentation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: add tag-triggered release workflow with GitHub Pages index"
+```
+
+---
+
+### Task 10: Rewrite README.md for end users
+
+**Files:**
+- Rewrite: `README.md`
+- Create: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Save current README content to CONTRIBUTING.md**
+
+Create `CONTRIBUTING.md` with the developer-focused content:
+
+```markdown
+# Contributing to Guru
+
+## Development setup
+
+```bash
+git clone https://github.com/martinmacak/guru.git
+cd guru
+uv sync --all-packages
+```
+
+## Running tests
+
+```bash
+uv run pytest                            # unit + integration tests
+uv run pytest packages/guru-core/        # guru-core tests only
+uv run pytest packages/guru-server/      # guru-server tests only
+uv run pytest packages/guru-mcp/         # guru-mcp tests only
+uv run pytest packages/guru-cli/         # guru-cli tests only
+uv run pytest -n auto                    # parallel (opt-in)
+uv run behave tests/e2e/features/        # BDD e2e tests
+./scripts/run-behave-parallel.sh         # e2e tests in parallel
+```
+
+## Project structure
+
+```
+packages/
+  guru-core/     shared client SDK (types, discovery, auto-start, HTTP client)
+  guru-server/   FastAPI daemon (LanceDB, Ollama, ingestion, REST API)
+  guru-mcp/      MCP protocol adapter (FastMCP, stdio)
+  guru-cli/      CLI (click) + TUI (Textual)
+```
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full architecture constitution.
+
+## Package dependencies
+
+```
+guru (meta-package)
+├── guru-core     (pydantic, httpx)
+├── guru-server   (guru-core, fastapi, lancedb, llama-index, ollama)
+├── guru-mcp      (guru-core, fastmcp)
+└── guru-cli      (guru-core, click, textual)
+```
+
+## Releasing
+
+Releases are automated via CI. To publish a new version:
+
+```bash
+git tag v0.2.0
+git push --tags
+```
+
+CI will build all wheels, create a GitHub Release, and deploy to the
+GitHub Pages package index automatically.
+
+## CI
+
+- `ci.yml` — unit tests per-package (skip if unchanged), e2e behind `require-e2e-tests` label
+- `release.yml` — builds and publishes on tag push
+- `claude-code-review.yml` — Claude review behind `require-claude-review` label
+```
+
+- [ ] **Step 2: Rewrite README.md for end users**
+
+Replace `README.md` with:
+
+```markdown
+# Guru
+
+A local-first knowledge-base manager that indexes markdown documents in a git repo and serves them to AI agents via RAG over MCP. Runs entirely on your machine with no cloud dependencies.
+
+## Prerequisites
+
+- Python >= 3.13
+- [uv](https://docs.astral.sh/uv/) (package manager)
+- [Ollama](https://ollama.com) with the `nomic-embed-text` model
+
+```bash
+# macOS
+brew install ollama
+
+# Linux — see https://ollama.com/download
+curl -fsSL https://ollama.com/install.sh | sh
+
+# Pull the embedding model
+ollama pull nomic-embed-text
+```
+
+## Install
+
+```bash
+uv tool install guru --extra-index-url https://martinmacak.github.io/guru/simple/
+```
+
+This installs the `guru`, `guru-server`, and `guru-mcp` commands.
+
+## Quick start
+
+```bash
+# Initialize guru in your markdown repo
+cd /path/to/your/repo
+guru init
+
+# Index your documents
+guru index
+
+# Search
+guru search "authentication flow"
+```
+
+`guru init` creates:
+- `.guru/` — runtime directory (gitignored automatically)
+- `guru.json` — indexing rules (version-controlled)
+- `.mcp.json` — MCP server configuration for AI agents
+
+## MCP integration
+
+After `guru init`, your `.mcp.json` is configured automatically. AI agents that support MCP (Claude Code, Cursor, Continue.dev) will discover the guru tools:
+
+- `search` — semantic search across your knowledge base
+- `get_document` — retrieve a full document
+- `list_documents` — browse all indexed documents
+- `get_section` — retrieve a specific markdown section
+- `index_status` — check index health and stats
+
+The guru server starts automatically when an MCP tool is first invoked.
+
+## Configuration
+
+Edit `guru.json` in your project root to control indexing:
+
+```json
+[
+  {
+    "ruleName": "docs",
+    "match": { "glob": "docs/**/*.md" },
+    "labels": ["documentation"]
+  },
+  {
+    "ruleName": "specs",
+    "match": { "glob": "specs/**/*.md" },
+    "labels": ["spec"]
+  },
+  {
+    "ruleName": "exclude-vendor",
+    "match": { "glob": "vendor/**" },
+    "exclude": true
+  }
+]
+```
+
+Config resolution: `./guru.json` > `./.guru/config.json` > `~/.config/guru/config.json`. Rules merge by `ruleName` (local overrides global).
+
+## CLI commands
+
+```
+guru init                # set up guru in current directory
+guru index [PATH]        # index documents
+guru search "query"      # semantic search
+guru doc <path>          # get full document
+guru doc <path> -s "H"   # get specific section
+guru list                # list indexed documents
+guru config              # show resolved config
+guru server start|stop|status
+```
+
+## Upgrade
+
+```bash
+uv tool upgrade guru --extra-index-url https://martinmacak.github.io/guru/simple/
+```
+
+## Uninstall
+
+```bash
+uv tool uninstall guru
+```
+
+## Troubleshooting
+
+**"guru-server did not start"**
+- Check that Ollama is running: `ollama list`
+- Ensure the embedding model is installed: `ollama pull nomic-embed-text`
+
+**"command not found: guru"**
+- Ensure `~/.local/bin` is on your PATH (uv tool install puts binaries there)
+- Run `uv tool list` to verify guru is installed
+
+**Server won't stop**
+- Run `guru server stop` or check `.guru/guru.pid` for the process ID
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and release process.
+
+## Architecture
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full architecture constitution.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md CONTRIBUTING.md
+git commit -m "docs: rewrite README for end users, add CONTRIBUTING.md
+
+README now covers install via uv tool, quick start, and MCP integration.
+Developer setup and testing docs moved to CONTRIBUTING.md."
+```
+
+---
+
+### Task 11: Verify full build pipeline locally
+
+**Files:** None (validation only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `uv run pytest -v --tb=short`
+Expected: all tests pass
+
+- [ ] **Step 2: Build all wheels**
+
+Run:
+
+```bash
+mkdir -p /tmp/guru-dist
+for pkg in packages/guru-core packages/guru-server packages/guru-mcp packages/guru-cli .; do
+  uv build --directory "$pkg" --out-dir /tmp/guru-dist/
+done
+ls -la /tmp/guru-dist/
+```
+
+Expected: 5 wheel files and 5 sdist tarballs in `/tmp/guru-dist/`. Version will be based on the latest git tag or a dev version.
+
+- [ ] **Step 3: Generate test index**
+
+Run:
+
+```bash
+python scripts/generate-index.py /tmp/guru-dist /tmp/guru-index
+find /tmp/guru-index -type f
+```
+
+Expected: root `index.html` + 5 per-package `index.html` files under `/tmp/guru-index/simple/`.
+
+- [ ] **Step 4: Verify index content**
+
+Run: `cat /tmp/guru-index/simple/index.html`
+Expected: HTML with links to all 5 packages
+
+Run: `cat /tmp/guru-index/simple/guru/index.html`
+Expected: HTML with link to `guru-*.whl`
+
+- [ ] **Step 5: Run BDD e2e tests (if Ollama available)**
+
+Run: `uv run behave tests/e2e/features/knowledge_base.feature tests/e2e/features/mcp_tools.feature`
+Expected: all scenarios pass (these use mocked embeddings, no Ollama needed)
+
+- [ ] **Step 6: Clean up**
+
+Run: `rm -rf /tmp/guru-dist /tmp/guru-index`
+
+- [ ] **Step 7: Commit any fixes discovered during validation**
+
+Only if issues were found. Otherwise skip.
+
+---
+
+### Task 12: Update CLAUDE.md with distribution info
+
+**Files:**
+- Modify: `CLAUDE.md` (project root)
+
+- [ ] **Step 1: Add distribution section to CLAUDE.md**
+
+Add after the "## Commands" section:
+
+```markdown
+## Distribution
+
+Guru is distributed via a PEP 503 simple index on GitHub Pages.
+Build backend is `hatchling` + `uv-dynamic-versioning` (version from git tags).
+
+```bash
+uv tool install guru --extra-index-url https://martinmacak.github.io/guru/simple/
+```
+
+### Releasing
+
+```bash
+git tag v0.2.0
+git push --tags
+# CI builds wheels, creates GitHub Release, deploys to Pages index
+```
+
+### Build locally
+
+```bash
+uv build                                 # build root meta-package
+uv build --directory packages/guru-core  # build single package
+```
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add distribution and release info to CLAUDE.md"
+```

--- a/docs/superpowers/specs/2026-04-09-packaging-distribution-design.md
+++ b/docs/superpowers/specs/2026-04-09-packaging-distribution-design.md
@@ -1,0 +1,337 @@
+# Guru Packaging & Distribution Design
+
+## Overview
+
+Distribute Guru as a `uv tool install`-able package via a PEP 503 simple Python
+index hosted on GitHub Pages. Users install with a single command, run `guru init`
+in their markdown repo, and start using Guru with their AI agent immediately.
+
+**Target audience:** Open-source developers using AI agents with MCP support.
+**Platforms:** macOS and Linux.
+
+## Install UX
+
+```bash
+# Install
+uv tool install guru --extra-index-url https://martinmacak.github.io/guru/simple/
+
+# Set up a repo
+cd my-markdown-repo
+guru init
+
+# Upgrade
+uv tool upgrade guru --extra-index-url https://martinmacak.github.io/guru/simple/
+
+# Uninstall
+uv tool uninstall guru
+```
+
+## 1. Package Structure
+
+### Meta-package
+
+The root `guru` package becomes a meta-package with no code or console scripts.
+It declares dependencies on all sub-packages:
+
+```toml
+[project]
+name = "guru"
+dynamic = ["version", "dependencies"]
+description = "Local-first knowledge base manager with MCP interface"
+requires-python = ">=3.13"
+
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.hatch.metadata.hooks.uv-dynamic-versioning]
+dependencies = [
+    "guru-core=={{ version }}",
+    "guru-server=={{ version }}",
+    "guru-mcp=={{ version }}",
+    "guru-cli=={{ version }}",
+]
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
+```
+
+The `{{ version }}` placeholders are substituted at build time by
+`uv-dynamic-versioning` from the git tag.
+
+### Console scripts
+
+Scripts remain defined in their respective sub-packages — `uv tool install` exposes
+all of them:
+
+| Script | Package | Entry point |
+|--------|---------|-------------|
+| `guru` | guru-cli | `guru_cli.cli:cli` |
+| `guru-server` | guru-server | `guru_server.main:main` |
+| `guru-mcp` | guru-mcp | `guru_mcp.server:main` |
+
+### Inter-package dependencies
+
+All inter-package dependencies use exact version pins (`=={{ version }}`),
+substituted at build time via `[tool.hatch.metadata.hooks.uv-dynamic-versioning]`.
+This guarantees version consistency:
+
+- `guru` depends on `guru-core`, `guru-server`, `guru-mcp`, `guru-cli`
+- `guru-server` depends on `guru-core`
+- `guru-mcp` depends on `guru-core`
+- `guru-cli` depends on `guru-core`
+
+Each of these is declared in the respective package's
+`[tool.hatch.metadata.hooks.uv-dynamic-versioning] dependencies` with
+`=={{ version }}` pins. Packages that have inter-package deps must list
+`"dependencies"` in `dynamic = [...]`.
+
+## 2. Versioning
+
+### Strategy: lockstep with dunamai
+
+All packages share the same version, derived automatically from git tags using
+`uv-dynamic-versioning` (which uses dunamai under the hood).
+
+**Changes to all 5 `pyproject.toml` files:**
+- Switch build backend from `uv_build` to `hatchling`
+- Add `uv-dynamic-versioning` to build-system requires
+- Remove `version = "0.1.0"`
+- Add `dynamic = ["version"]` (and `"dependencies"` for packages with inter-package deps)
+- Add `[tool.hatch.version]`, `[tool.uv-dynamic-versioning]` configuration
+- Add `[tool.hatch.metadata.hooks.uv-dynamic-versioning]` for inter-package deps
+
+**Version derivation:**
+- Tag `v0.2.0` → version `0.2.0` for all packages
+- Untagged commits get a dev version (e.g., `0.2.0.dev3+gabcdef`)
+
+**Release workflow:**
+```bash
+git tag v0.2.0
+git push --tags
+# CI handles everything from here
+```
+
+### Build backend: hatchling + uv-dynamic-versioning
+
+All packages switch from `uv_build` to `hatchling`. The `uv_build` backend does
+not support dynamic versioning ([astral-sh/uv#14946](https://github.com/astral-sh/uv/issues/14946)).
+`hatchling` is the [recommended alternative](https://docs.astral.sh/uv/concepts/build-backend/)
+for projects needing more flexibility. This switch has zero impact on the dev
+workflow — `uv sync`, `uv run`, `uv build` all work identically with `hatchling`.
+
+**Build system (all 5 packages):**
+```toml
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+```
+
+**Version source (all 5 packages):**
+```toml
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
+```
+
+**Dynamic dependencies (packages with inter-package deps):**
+
+For packages with inter-package deps, both dynamic and static deps are declared
+in the metadata hook. When `"dependencies"` is listed in `dynamic = [...]`, the
+hook's `dependencies` list **replaces** `project.dependencies` entirely. Therefore
+all dependencies (both inter-package and external) must be listed in the hook.
+
+Example for `guru-server`:
+```toml
+[project]
+name = "guru-server"
+dynamic = ["version", "dependencies"]
+
+[tool.hatch.metadata.hooks.uv-dynamic-versioning]
+dependencies = [
+    "guru-core=={{ version }}",
+    "httpx>=0.28",
+    "pydantic>=2.0",
+    "llama-index-core>=0.14",
+    "python-frontmatter>=1.1",
+    "lancedb>=0.27",
+    "pandas>=2.0",
+    "fastapi>=0.115",
+    "uvicorn>=0.34",
+]
+```
+
+The `{{ version }}` placeholder is substituted at build time. Static deps like
+`fastapi>=0.115` pass through unchanged.
+
+For `guru-core` (no inter-package deps), only `dynamic = ["version"]` is needed
+and dependencies stay in `[project]` as normal.
+
+**Version derivation:**
+- Tag `v0.2.0` → version `0.2.0`
+- Pattern: default dunamai pattern matching `v*` tags
+- Style: PEP 440
+
+## 3. GitHub Pages Simple Index
+
+### Structure
+
+A PEP 503-compliant simple repository index on the `gh-pages` branch:
+
+```
+simple/
+├── index.html                  # root: links to each package
+├── guru/
+│   └── index.html              # links to guru wheels
+├── guru-core/
+│   └── index.html              # links to guru-core wheels
+├── guru-server/
+│   └── index.html              # links to guru-server wheels
+├── guru-mcp/
+│   └── index.html              # links to guru-mcp wheels
+└── guru-cli/
+    └── index.html              # links to guru-cli wheels
+wheels/
+├── guru-0.1.0-py3-none-any.whl
+├── guru_core-0.1.0-py3-none-any.whl
+├── guru_server-0.1.0-py3-none-any.whl
+├── guru_mcp-0.1.0-py3-none-any.whl
+└── guru_cli-0.1.0-py3-none-any.whl
+```
+
+### Index generation
+
+A script (`scripts/generate-index.py`) scans the `wheels/` directory and generates
+PEP 503-compliant HTML:
+
+- Root `simple/index.html`: one `<a>` per package name
+- Per-package `simple/<name>/index.html`: one `<a href>` per wheel file
+
+Old versions remain available — new releases add new wheels and regenerate the
+index HTML files.
+
+### URL
+
+```
+https://martinmacak.github.io/guru/simple/
+```
+
+PyPI remains the default index for transitive dependencies (FastAPI, LanceDB,
+pydantic, etc.). Only `guru-*` packages are served from this index.
+
+## 4. CI/CD Release Pipeline
+
+### Workflow: `.github/workflows/release.yml`
+
+**Trigger:** Push of tag matching `v*`
+
+**Steps:**
+
+1. **Checkout** source at the tagged commit
+2. **Setup** Python 3.13 + uv
+3. **Build wheels** for all 5 packages using `uv build`. Dynamic versioning
+   derives version from the git tag automatically.
+4. **Create GitHub Release** — attach all 5 wheels as release assets,
+   auto-generate release notes from commits since last tag
+5. **Deploy to GitHub Pages:**
+   - Checkout `gh-pages` branch (create if first release)
+   - Copy new wheels into `wheels/`
+   - Run `scripts/generate-index.py` to regenerate `simple/*/index.html`
+   - Commit and push to `gh-pages`
+
+### First-time setup
+
+- Enable GitHub Pages for the repo (source: `gh-pages` branch)
+- The first release workflow run creates the `gh-pages` branch if it doesn't exist
+
+### Tag format
+
+Only stable `vX.Y.Z` tags trigger the pipeline. Pre-release tags are not supported
+initially.
+
+## 5. `guru init` Enhancements
+
+`guru init` becomes the single setup command for new repos. It is idempotent —
+running it twice is safe.
+
+**Actions:**
+
+1. **Create `.guru/` directory** (existing behavior)
+2. **Create `guru.json`** with default indexing rules (existing behavior)
+3. **Merge guru entry into `.mcp.json`** (new):
+   - If `.mcp.json` exists: read, add `guru` under `mcpServers`, write back.
+     Preserves existing entries.
+   - If `.mcp.json` doesn't exist: create with guru entry only.
+   - If `guru` already present in `.mcp.json`: skip with message.
+   - Entry content: `{"command": "guru-mcp"}`
+4. **Add `.guru/` to `.gitignore`** (new):
+   - If `.gitignore` exists: append `.guru/` if not already present.
+   - If `.gitignore` doesn't exist: create with `.guru/`.
+
+**Output:**
+```
+Created .guru/
+Created guru.json with default rules
+Added guru to .mcp.json
+Added .guru/ to .gitignore
+```
+
+Skipped steps print accordingly (e.g., "guru.json already exists, skipping").
+
+## 6. Auto-start
+
+`guru-mcp` auto-starts `guru-server` via `guru_core.autostart.ensure_server()`.
+The current implementation uses `subprocess.Popen(["guru-server"], ...)`, which
+finds `guru-server` on PATH. This works correctly with `uv tool install` because
+all console scripts from the meta-package's dependencies are symlinked into the
+same `~/.local/bin/` directory.
+
+No changes needed to the auto-start mechanism.
+
+## 7. Documentation
+
+### README.md (rewrite for end users)
+
+1. What is Guru (one paragraph)
+2. Prerequisites (Python 3.13+, uv, Ollama, `ollama pull nomic-embed-text`)
+3. Install (one-liner with `--extra-index-url`)
+4. Quick Start (`guru init`, `guru index`, open AI agent)
+5. Configuration (`guru.json` format, rules, labels, chunking)
+6. Upgrade command
+7. Uninstall command
+8. Troubleshooting (common issues)
+
+### CONTRIBUTING.md (new, for developers)
+
+- Dev setup (`git clone`, `uv sync --all-packages`)
+- Running tests (pytest, behave, parallel)
+- Project structure and package boundaries
+- Architecture overview (pointer to ARCHITECTURE.md)
+- Release process (tag and push)
+
+### License
+
+A LICENSE file must be added before the first public release. Choice of license
+is a prerequisite but outside the scope of this design.
+
+## 8. Deliverables Summary
+
+| Deliverable | Type | Description |
+|-------------|------|-------------|
+| Root `pyproject.toml` | Modify | Add sub-package dependencies, dynamic version |
+| All 5 `pyproject.toml` | Modify | Switch to hatchling, dynamic versioning, exact inter-package pins |
+| `scripts/generate-index.py` | New | PEP 503 index HTML generator |
+| `.github/workflows/release.yml` | New | Tag-triggered build + publish pipeline |
+| `guru init` in guru-cli | Modify | Add `.mcp.json` merge and `.gitignore` update |
+| `README.md` | Rewrite | User-facing install and usage guide |
+| `CONTRIBUTING.md` | New | Developer guide (current README content) |
+| `LICENSE` | New | License file (prerequisite, choice TBD) |

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+python = "3.13"
+pre-commit = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,4 @@
 [tools]
 python = "3.13"
 pre-commit = "latest"
+jq = "latest"

--- a/packages/guru-cli/pyproject.toml
+++ b/packages/guru-cli/pyproject.toml
@@ -1,27 +1,37 @@
 [project]
 name = "guru-cli"
-version = "0.1.0"
+dynamic = ["version", "dependencies"]
 description = "Guru CLI and TUI"
 readme = "README.md"
 authors = [
     { name = "Martin Macak", email = "martin.macak@gmail.com" }
 ]
 requires-python = ">=3.13"
-dependencies = [
-    "guru-core",
-    "click>=8.1",
-    "textual>=0.80",
-]
 
 [project.scripts]
 guru = "guru_cli.cli:cli"
 
-[build-system]
-requires = ["uv_build>=0.10.3,<0.11.0"]
-build-backend = "uv_build"
-
 [tool.uv.sources]
 guru-core = { workspace = true }
+
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.hatch.metadata.hooks.uv-dynamic-versioning]
+dependencies = [
+    "guru-core=={{ version }}",
+    "click>=8.1",
+    "textual>=0.80",
+]
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
 
 [dependency-groups]
 dev = [

--- a/packages/guru-cli/src/guru_cli/cli.py
+++ b/packages/guru-cli/src/guru_cli/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import sys
 from importlib.metadata import version as pkg_version
@@ -8,10 +9,9 @@ from pathlib import Path
 
 import click
 
-from guru_core.discovery import find_guru_root, GuruNotFoundError
 from guru_core.autostart import ensure_server
 from guru_core.client import GuruClient
-
+from guru_core.discovery import GuruNotFoundError, find_guru_root
 
 DEFAULT_CONFIG = [
     {"ruleName": "default", "match": {"glob": "**/*.md"}},
@@ -223,13 +223,11 @@ def list_docs():
 @cli.command()
 def config():
     """Show resolved configuration with provenance."""
-    from guru_core.config import load_rules, merge_rules, DEFAULT_RULES
+    from guru_core.config import DEFAULT_RULES, load_rules, merge_rules
 
     guru_root = Path.cwd()
-    try:
+    with contextlib.suppress(GuruNotFoundError):
         guru_root = find_guru_root(Path.cwd())
-    except GuruNotFoundError:
-        pass
 
     global_path = Path.home() / ".config" / "guru" / "config.json"
     local_path = guru_root / "guru.json"

--- a/packages/guru-cli/src/guru_cli/cli.py
+++ b/packages/guru-cli/src/guru_cli/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+from importlib.metadata import version as pkg_version
 from pathlib import Path
 
 import click
@@ -34,7 +35,7 @@ def _run(coro):
 
 
 @click.group(invoke_without_command=True)
-@click.version_option(version="0.1.0")
+@click.version_option(version=pkg_version("guru-cli"))
 @click.pass_context
 def cli(ctx):
     """Guru CLI — local knowledge base manager."""

--- a/packages/guru-cli/src/guru_cli/cli.py
+++ b/packages/guru-cli/src/guru_cli/cli.py
@@ -53,20 +53,68 @@ def tui():
 @cli.command()
 def init():
     """Initialize a guru project in the current directory."""
-    guru_dir = Path.cwd() / ".guru"
-    guru_json = Path.cwd() / "guru.json"
+    cwd = Path.cwd()
+    guru_dir = cwd / ".guru"
+    guru_json = cwd / "guru.json"
+    mcp_json = cwd / ".mcp.json"
+    gitignore = cwd / ".gitignore"
 
+    # 1. Create .guru/ directory
     if guru_dir.is_dir():
         click.echo("Already initialized — .guru/ directory exists.")
-        return
+    else:
+        guru_dir.mkdir()
+        (guru_dir / "db").mkdir()
+        click.echo("Created .guru/")
 
-    guru_dir.mkdir()
-    (guru_dir / "db").mkdir()
-
-    if not guru_json.exists():
+    # 2. Create guru.json
+    if guru_json.exists():
+        click.echo("guru.json already exists, skipping.")
+    else:
         guru_json.write_text(json.dumps(DEFAULT_CONFIG, indent=2) + "\n")
+        click.echo("Created guru.json with default rules")
 
-    click.echo(f"Initialized guru project in {Path.cwd()}")
+    # 3. Merge guru into .mcp.json
+    _init_mcp_json(mcp_json)
+
+    # 4. Add .guru/ to .gitignore
+    _init_gitignore(gitignore)
+
+
+def _init_mcp_json(mcp_json: Path) -> None:
+    """Add guru entry to .mcp.json, creating or merging as needed."""
+    guru_entry = {"command": "guru-mcp"}
+
+    if mcp_json.exists():
+        mcp = json.loads(mcp_json.read_text())
+        servers = mcp.setdefault("mcpServers", {})
+        if "guru" in servers:
+            click.echo("guru already configured in .mcp.json, skipping.")
+            return
+        servers["guru"] = guru_entry
+    else:
+        mcp = {"mcpServers": {"guru": guru_entry}}
+
+    mcp_json.write_text(json.dumps(mcp, indent=2) + "\n")
+    click.echo("Added guru to .mcp.json")
+
+
+def _init_gitignore(gitignore: Path) -> None:
+    """Add .guru/ to .gitignore if not already present."""
+    marker = ".guru/"
+    if gitignore.exists():
+        content = gitignore.read_text()
+        if marker in content.splitlines():
+            click.echo(".guru/ already in .gitignore, skipping.")
+            return
+        if not content.endswith("\n"):
+            content += "\n"
+        content += marker + "\n"
+    else:
+        content = marker + "\n"
+
+    gitignore.write_text(content)
+    click.echo("Added .guru/ to .gitignore")
 
 
 @cli.group()

--- a/packages/guru-cli/tests/test_cli.py
+++ b/packages/guru-cli/tests/test_cli.py
@@ -24,7 +24,7 @@ def test_init_creates_guru_dir(runner, tmp_path):
         result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
         assert (Path(td) / ".guru").is_dir()
-        assert "Initialized" in result.output
+        assert "Created .guru/" in result.output
 
 
 def test_init_with_config(runner, tmp_path):
@@ -43,6 +43,82 @@ def test_init_already_initialized(runner, tmp_path):
         result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
         assert "already initialized" in result.output.lower()
+
+
+def test_init_creates_mcp_json(runner, tmp_path):
+    """guru init creates .mcp.json with guru entry when file doesn't exist."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        mcp_file = Path(td) / ".mcp.json"
+        assert mcp_file.is_file()
+        mcp = json.loads(mcp_file.read_text())
+        assert mcp["mcpServers"]["guru"]["command"] == "guru-mcp"
+        assert "Added guru to .mcp.json" in result.output
+
+
+def test_init_merges_into_existing_mcp_json(runner, tmp_path):
+    """guru init preserves existing MCP servers when adding guru."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        mcp_file = Path(td) / ".mcp.json"
+        mcp_file.write_text(json.dumps({
+            "mcpServers": {
+                "other-tool": {"command": "other-tool-mcp"}
+            }
+        }))
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        mcp = json.loads(mcp_file.read_text())
+        assert "other-tool" in mcp["mcpServers"]
+        assert "guru" in mcp["mcpServers"]
+
+
+def test_init_skips_existing_guru_mcp_entry(runner, tmp_path):
+    """guru init skips .mcp.json if guru entry already exists."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        mcp_file = Path(td) / ".mcp.json"
+        mcp_file.write_text(json.dumps({
+            "mcpServers": {
+                "guru": {"command": "guru-mcp"}
+            }
+        }))
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        assert "guru already configured in .mcp.json" in result.output
+
+
+def test_init_creates_gitignore(runner, tmp_path):
+    """guru init creates .gitignore with .guru/ when file doesn't exist."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        gitignore = Path(td) / ".gitignore"
+        assert gitignore.is_file()
+        assert ".guru/" in gitignore.read_text().splitlines()
+        assert "Added .guru/ to .gitignore" in result.output
+
+
+def test_init_appends_to_existing_gitignore(runner, tmp_path):
+    """guru init appends .guru/ to existing .gitignore."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        gitignore = Path(td) / ".gitignore"
+        gitignore.write_text("node_modules/\n.env\n")
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        lines = gitignore.read_text().splitlines()
+        assert "node_modules/" in lines
+        assert ".env" in lines
+        assert ".guru/" in lines
+
+
+def test_init_skips_existing_gitignore_entry(runner, tmp_path):
+    """guru init skips .gitignore if .guru/ already present."""
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        gitignore = Path(td) / ".gitignore"
+        gitignore.write_text(".guru/\n")
+        result = runner.invoke(cli, ["init"])
+        assert result.exit_code == 0
+        assert ".guru/ already in .gitignore" in result.output
 
 
 def test_config_shows_resolved(runner, tmp_path):

--- a/packages/guru-cli/tests/test_cli.py
+++ b/packages/guru-cli/tests/test_cli.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 from click.testing import CliRunner
@@ -61,11 +60,9 @@ def test_init_merges_into_existing_mcp_json(runner, tmp_path):
     """guru init preserves existing MCP servers when adding guru."""
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
         mcp_file = Path(td) / ".mcp.json"
-        mcp_file.write_text(json.dumps({
-            "mcpServers": {
-                "other-tool": {"command": "other-tool-mcp"}
-            }
-        }))
+        mcp_file.write_text(
+            json.dumps({"mcpServers": {"other-tool": {"command": "other-tool-mcp"}}})
+        )
         result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
         mcp = json.loads(mcp_file.read_text())
@@ -77,11 +74,7 @@ def test_init_skips_existing_guru_mcp_entry(runner, tmp_path):
     """guru init skips .mcp.json if guru entry already exists."""
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
         mcp_file = Path(td) / ".mcp.json"
-        mcp_file.write_text(json.dumps({
-            "mcpServers": {
-                "guru": {"command": "guru-mcp"}
-            }
-        }))
+        mcp_file.write_text(json.dumps({"mcpServers": {"guru": {"command": "guru-mcp"}}}))
         result = runner.invoke(cli, ["init"])
         assert result.exit_code == 0
         assert "guru already configured in .mcp.json" in result.output
@@ -126,9 +119,13 @@ def test_config_shows_resolved(runner, tmp_path):
         td_path = Path(td)
         (td_path / ".guru").mkdir()
         guru_json = td_path / "guru.json"
-        guru_json.write_text(json.dumps([
-            {"ruleName": "specs", "match": {"glob": "specs/**/*.md"}, "labels": ["spec"]},
-        ]))
+        guru_json.write_text(
+            json.dumps(
+                [
+                    {"ruleName": "specs", "match": {"glob": "specs/**/*.md"}, "labels": ["spec"]},
+                ]
+            )
+        )
         result = runner.invoke(cli, ["config"])
         assert result.exit_code == 0
         assert "specs" in result.output

--- a/packages/guru-cli/tests/test_cli.py
+++ b/packages/guru-cli/tests/test_cli.py
@@ -16,7 +16,7 @@ def runner():
 def test_cli_version(runner):
     result = runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
-    assert "0.1.0" in result.output
+    assert "version" in result.output.lower() or "." in result.output
 
 
 def test_init_creates_guru_dir(runner, tmp_path):

--- a/packages/guru-core/pyproject.toml
+++ b/packages/guru-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "guru-core"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Guru shared client SDK and types"
 requires-python = ">=3.13"
 dependencies = [
@@ -9,8 +9,16 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.10.3,<0.11.0"]
-build-backend = "uv_build"
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
 
 [dependency-groups]
 dev = [

--- a/packages/guru-core/src/guru_core/__init__.py
+++ b/packages/guru-core/src/guru_core/__init__.py
@@ -1,3 +1,12 @@
+from guru_core.autostart import ServerStartError, ensure_server
+from guru_core.client import GuruClient
+from guru_core.config import (
+    DEFAULT_RULES,
+    load_rules,
+    merge_rules,
+    resolve_config,
+)
+from guru_core.discovery import GuruNotFoundError, find_guru_root
 from guru_core.types import (
     ChunkingConfig,
     DocumentInfo,
@@ -14,19 +23,10 @@ from guru_core.types import (
     StatusOut,
     StatusResponse,
 )
-from guru_core.config import (
-    DEFAULT_RULES,
-    load_rules,
-    merge_rules,
-    resolve_config,
-)
-from guru_core.discovery import find_guru_root, GuruNotFoundError
-from guru_core.client import GuruClient
-from guru_core.autostart import ensure_server, ServerStartError
 
 __all__ = [
-    "ChunkingConfig",
     "DEFAULT_RULES",
+    "ChunkingConfig",
     "DocumentInfo",
     "DocumentListItem",
     "DocumentOut",

--- a/packages/guru-core/src/guru_core/autostart.py
+++ b/packages/guru-core/src/guru_core/autostart.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import signal
 import subprocess
 import time
 from pathlib import Path
@@ -92,5 +91,5 @@ def _health_check(sock_path: str) -> Exception | None:
             resp = client.get("http://localhost/status")
             resp.raise_for_status()
         return None
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return exc

--- a/packages/guru-core/src/guru_core/client.py
+++ b/packages/guru-core/src/guru_core/client.py
@@ -33,14 +33,15 @@ class GuruClient:
     async def status(self) -> dict:
         return await self._get("/status")
 
-    async def search(
-        self, query: str, n_results: int = 10, filters: dict | None = None
-    ) -> list:
-        return await self._post("/search", {
-            "query": query,
-            "n_results": n_results,
-            "filters": filters or {},
-        })
+    async def search(self, query: str, n_results: int = 10, filters: dict | None = None) -> list:
+        return await self._post(
+            "/search",
+            {
+                "query": query,
+                "n_results": n_results,
+                "filters": filters or {},
+            },
+        )
 
     async def list_documents(self, filters: dict | None = None) -> list:
         path = "/documents"

--- a/packages/guru-core/src/guru_core/config.py
+++ b/packages/guru-core/src/guru_core/config.py
@@ -19,9 +19,7 @@ def load_rules(path: Path) -> list[Rule] | None:
     return [Rule(**item) for item in data]
 
 
-def merge_rules(
-    global_rules: list[Rule], local_rules: list[Rule]
-) -> list[Rule]:
+def merge_rules(global_rules: list[Rule], local_rules: list[Rule]) -> list[Rule]:
     """Merge local rules over global rules.
 
     Rules with the same rule_name in local fully replace the global version.

--- a/packages/guru-core/src/guru_core/discovery.py
+++ b/packages/guru-core/src/guru_core/discovery.py
@@ -19,7 +19,5 @@ def find_guru_root(start: Path) -> Path:
             return current
         parent = current.parent
         if parent == current:
-            raise GuruNotFoundError(
-                "Not a guru project. Run `guru init` first."
-            )
+            raise GuruNotFoundError("Not a guru project. Run `guru init` first.")
         current = parent

--- a/packages/guru-core/src/guru_core/types.py
+++ b/packages/guru-core/src/guru_core/types.py
@@ -33,6 +33,7 @@ class SearchRequest(BaseModel):
 
 # --- API response models (canonical source of truth) ---
 
+
 class SearchResultOut(BaseModel):
     file_path: str
     header_breadcrumb: str
@@ -80,12 +81,14 @@ class IndexOut(BaseModel):
 
 # --- Legacy / extended models kept for backward compatibility ---
 
+
 class SearchResult(SearchResultOut):
     """Alias for SearchResultOut."""
 
 
 class DocumentInfo(BaseModel):
     """Extended document model that includes last_indexed timestamp."""
+
     file_path: str
     content: str
     frontmatter: dict[str, Any] = Field(default_factory=dict)
@@ -96,6 +99,7 @@ class DocumentInfo(BaseModel):
 
 class SectionInfo(BaseModel):
     """Section model using header_path naming convention."""
+
     file_path: str
     header_path: str
     content: str

--- a/packages/guru-core/tests/test_client.py
+++ b/packages/guru-core/tests/test_client.py
@@ -1,12 +1,11 @@
-import json
 from pathlib import Path
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
 
+from guru_core.autostart import ServerStartError, _health_check, ensure_server
 from guru_core.client import GuruClient
-from guru_core.autostart import ensure_server, ServerStartError, _health_check
 
 
 class TestGuruClient:
@@ -26,14 +25,17 @@ class TestGuruClient:
 
     @pytest.mark.asyncio
     async def test_status(self, guru_root, monkeypatch):
-        fake_response = httpx.Response(200, json={
-            "server_running": True,
-            "document_count": 10,
-            "chunk_count": 50,
-            "last_indexed": None,
-            "ollama_available": True,
-            "model_loaded": True,
-        })
+        fake_response = httpx.Response(
+            200,
+            json={
+                "server_running": True,
+                "document_count": 10,
+                "chunk_count": 50,
+                "last_indexed": None,
+                "ollama_available": True,
+                "model_loaded": True,
+            },
+        )
 
         async def fake_get(self, url, **kwargs):
             return fake_response
@@ -47,10 +49,19 @@ class TestGuruClient:
 
     @pytest.mark.asyncio
     async def test_search(self, guru_root, monkeypatch):
-        fake_response = httpx.Response(200, json=[
-            {"file_path": "auth.md", "content": "OAuth", "score": 0.9,
-             "header_breadcrumb": "Auth", "chunk_level": 2, "labels": "[]"},
-        ])
+        fake_response = httpx.Response(
+            200,
+            json=[
+                {
+                    "file_path": "auth.md",
+                    "content": "OAuth",
+                    "score": 0.9,
+                    "header_breadcrumb": "Auth",
+                    "chunk_level": 2,
+                    "labels": "[]",
+                },
+            ],
+        )
 
         async def fake_post(self, url, **kwargs):
             return fake_response
@@ -98,6 +109,7 @@ class TestEnsureServer:
         # Mock socket check to succeed after start
         call_count = 0
         original_exists = Path.exists
+
         def fake_exists(self):
             nonlocal call_count
             if self.name == "guru.sock":
@@ -108,9 +120,7 @@ class TestEnsureServer:
         monkeypatch.setattr(Path, "exists", fake_exists)
 
         # Mock health check to succeed once the socket appears
-        monkeypatch.setattr(
-            "guru_core.autostart._health_check", lambda sock_path: None
-        )
+        monkeypatch.setattr("guru_core.autostart._health_check", lambda sock_path: None)
 
         ensure_server(tmp_path)
         assert not pid_file.exists() or pid_file.read_text() != "99999"
@@ -125,14 +135,20 @@ class TestEnsureServer:
         pid_file.write_text("99999")
 
         # Stale process
-        monkeypatch.setattr("os.kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()))
+        monkeypatch.setattr(
+            "os.kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
+        )
 
         # Mock subprocess
         monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: MagicMock())
 
         # Socket always appears immediately
         original_exists = Path.exists
-        monkeypatch.setattr(Path, "exists", lambda self: True if self.name == "guru.sock" else original_exists(self))
+        monkeypatch.setattr(
+            Path,
+            "exists",
+            lambda self: True if self.name == "guru.sock" else original_exists(self),
+        )
 
         # Health check always fails
         monkeypatch.setattr(
@@ -158,6 +174,7 @@ class TestEnsureServer:
 
     def test_health_check_connection_error(self, tmp_path, monkeypatch):
         """_health_check returns the exception when the connection fails."""
+
         def fake_send(self, request, **kwargs):
             raise httpx.ConnectError("refused")
 

--- a/packages/guru-core/tests/test_discovery.py
+++ b/packages/guru-core/tests/test_discovery.py
@@ -1,9 +1,6 @@
-import os
-from pathlib import Path
-
 import pytest
 
-from guru_core.discovery import find_guru_root, GuruNotFoundError
+from guru_core.discovery import GuruNotFoundError, find_guru_root
 
 
 def test_find_guru_root_in_current_dir(tmp_path):

--- a/packages/guru-core/tests/test_types.py
+++ b/packages/guru-core/tests/test_types.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 
 from guru_core.types import (
-    MatchConfig,
     ChunkingConfig,
+    DocumentInfo,
+    MatchConfig,
     Rule,
     SearchRequest,
     SearchResult,
-    DocumentInfo,
     SectionInfo,
     StatusResponse,
 )

--- a/packages/guru-mcp/pyproject.toml
+++ b/packages/guru-mcp/pyproject.toml
@@ -1,26 +1,36 @@
 [project]
 name = "guru-mcp"
-version = "0.1.0"
+dynamic = ["version", "dependencies"]
 description = "Guru MCP protocol adapter"
 readme = "README.md"
 authors = [
     { name = "Martin Macak", email = "martin.macak@gmail.com" }
 ]
 requires-python = ">=3.13"
-dependencies = [
-    "guru-core",
-    "fastmcp>=2.0",
-]
 
 [project.scripts]
 guru-mcp = "guru_mcp.server:main"
 
-[build-system]
-requires = ["uv_build>=0.10.3,<0.11.0"]
-build-backend = "uv_build"
-
 [tool.uv.sources]
 guru-core = { workspace = true }
+
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.hatch.metadata.hooks.uv-dynamic-versioning]
+dependencies = [
+    "guru-core=={{ version }}",
+    "fastmcp>=2.0",
+]
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
 
 [dependency-groups]
 dev = [

--- a/packages/guru-mcp/src/guru_mcp/server.py
+++ b/packages/guru-mcp/src/guru_mcp/server.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 from fastmcp import FastMCP
 
-from guru_core.discovery import find_guru_root
 from guru_core.autostart import ensure_server
 from guru_core.client import GuruClient
+from guru_core.discovery import find_guru_root
 
 mcp = FastMCP("guru")
 

--- a/packages/guru-server/pyproject.toml
+++ b/packages/guru-server/pyproject.toml
@@ -1,14 +1,29 @@
 [project]
 name = "guru-server"
-version = "0.1.0"
-description = "Add your description here"
+dynamic = ["version", "dependencies"]
+description = "Guru FastAPI server — owns all state (LanceDB, Ollama, ingestion)"
 readme = "README.md"
 authors = [
     { name = "Martin Macak", email = "martin.macak@gmail.com" }
 ]
 requires-python = ">=3.13"
+
+[project.scripts]
+guru-server = "guru_server.main:main"
+
+[tool.uv.sources]
+guru-core = { workspace = true }
+
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.hatch.metadata.hooks.uv-dynamic-versioning]
 dependencies = [
-    "guru-core",
+    "guru-core=={{ version }}",
     "httpx>=0.28",
     "pydantic>=2.0",
     "llama-index-core>=0.14",
@@ -19,15 +34,10 @@ dependencies = [
     "uvicorn>=0.34",
 ]
 
-[project.scripts]
-guru-server = "guru_server.main:main"
-
-[tool.uv.sources]
-guru-core = { workspace = true }
-
-[build-system]
-requires = ["uv_build>=0.10.3,<0.11.0"]
-build-backend = "uv_build"
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
 
 [dependency-groups]
 dev = [

--- a/packages/guru-server/src/guru_server/api/__init__.py
+++ b/packages/guru-server/src/guru_server/api/__init__.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter
 
-from guru_server.api.search import router as search_router
 from guru_server.api.documents import router as documents_router
 from guru_server.api.index import router as index_router
+from guru_server.api.search import router as search_router
 from guru_server.api.status import router as status_router
 
 api_router = APIRouter()

--- a/packages/guru-server/src/guru_server/api/documents.py
+++ b/packages/guru-server/src/guru_server/api/documents.py
@@ -30,8 +30,7 @@ async def list_documents(request: Request):
                 if part:
                     requested_labels.add(part)
         documents = [
-            doc for doc in documents
-            if requested_labels.issubset(set(doc.get("labels", [])))
+            doc for doc in documents if requested_labels.issubset(set(doc.get("labels", [])))
         ]
 
     return documents

--- a/packages/guru-server/src/guru_server/api/index.py
+++ b/packages/guru-server/src/guru_server/api/index.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
@@ -32,6 +32,7 @@ async def trigger_index(body: IndexBody, request: Request):
         target = project_root
 
     from guru_server.ingestion.markdown import MarkdownParser
+
     parser = MarkdownParser()
 
     # Collect the set of files excluded by any exclude rule (using Path.glob for ** support)
@@ -72,7 +73,7 @@ async def trigger_index(body: IndexBody, request: Request):
         vectors = await embedder.embed_batch(texts)
         store.add_chunks(all_chunks, vectors)
 
-    request.app.state.last_indexed = datetime.now(timezone.utc)
+    request.app.state.last_indexed = datetime.now(UTC)
 
     return {
         "indexed": len(all_chunks),

--- a/packages/guru-server/src/guru_server/api/models.py
+++ b/packages/guru-server/src/guru_server/api/models.py
@@ -1,18 +1,19 @@
 """API response/request models — re-exported from guru_core.types (canonical source)."""
+
 from guru_core.types import (
-    SearchResultOut,
     DocumentListItem,
     DocumentOut,
+    IndexOut,
+    SearchResultOut,
     SectionOut,
     StatusOut,
-    IndexOut,
 )
 
 __all__ = [
-    "SearchResultOut",
     "DocumentListItem",
     "DocumentOut",
+    "IndexOut",
+    "SearchResultOut",
     "SectionOut",
     "StatusOut",
-    "IndexOut",
 ]

--- a/packages/guru-server/src/guru_server/config.py
+++ b/packages/guru-server/src/guru_server/config.py
@@ -1,4 +1,5 @@
 """Config module — re-exported from guru_core.config (canonical source)."""
+
 from guru_core.config import (
     DEFAULT_RULES,
     load_rules,

--- a/packages/guru-server/src/guru_server/embedding.py
+++ b/packages/guru-server/src/guru_server/embedding.py
@@ -20,7 +20,9 @@ class OllamaEmbedder:
                 timeout=30.0,
             )
         if response.status_code != 200:
-            raise EmbeddingError(f"Ollama embedding failed ({response.status_code}): {response.text}")
+            raise EmbeddingError(
+                f"Ollama embedding failed ({response.status_code}): {response.text}"
+            )
         return response.json()["embedding"]
 
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:

--- a/packages/guru-server/src/guru_server/ingestion/__init__.py
+++ b/packages/guru-server/src/guru_server/ingestion/__init__.py
@@ -1,3 +1,4 @@
 from guru_server.ingestion.base import Chunk, DocumentParser
 from guru_server.ingestion.markdown import MarkdownParser
+
 __all__ = ["Chunk", "DocumentParser", "MarkdownParser"]

--- a/packages/guru-server/src/guru_server/ingestion/base.py
+++ b/packages/guru-server/src/guru_server/ingestion/base.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
 from guru_core.types import Rule
+
 
 @dataclass
 class Chunk:
@@ -16,6 +19,7 @@ class Chunk:
     parent_chunk_id: str | None = None
     chunk_id: str | None = None
     content_type: str = "text"  # "text", "code", "table", "mixed"
+
 
 class DocumentParser(ABC):
     @abstractmethod

--- a/packages/guru-server/src/guru_server/ingestion/markdown.py
+++ b/packages/guru-server/src/guru_server/ingestion/markdown.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
+
 import hashlib
 import re
 from pathlib import Path
+
 import frontmatter
 from llama_index.core import Document
 from llama_index.core.node_parser import MarkdownNodeParser as LlamaMarkdownParser
+
 from guru_core.types import Rule
 from guru_server.ingestion.base import Chunk, DocumentParser
 
@@ -46,18 +49,22 @@ class MarkdownParser(DocumentParser):
         for i, node in enumerate(nodes):
             header_breadcrumb = self._extract_breadcrumb(node)
             chunk_level = self._infer_level(header_breadcrumb)
-            chunk_id = hashlib.sha256(f"{file_path}:{header_breadcrumb}:{i}".encode()).hexdigest()[:16]
+            chunk_id = hashlib.sha256(f"{file_path}:{header_breadcrumb}:{i}".encode()).hexdigest()[
+                :16
+            ]
             content = node.get_content()
-            chunks.append(Chunk(
-                content=content,
-                file_path=str(file_path),
-                header_breadcrumb=header_breadcrumb,
-                chunk_level=chunk_level,
-                frontmatter=fm,
-                labels=list(rule.labels),
-                chunk_id=chunk_id,
-                content_type=_detect_content_type(content),
-            ))
+            chunks.append(
+                Chunk(
+                    content=content,
+                    file_path=str(file_path),
+                    header_breadcrumb=header_breadcrumb,
+                    chunk_level=chunk_level,
+                    frontmatter=fm,
+                    labels=list(rule.labels),
+                    chunk_id=chunk_id,
+                    content_type=_detect_content_type(content),
+                )
+            )
 
         # Apply split_level: if "h2", merge level-3 chunks into their parent level-2 chunk
         if split_level == "h2":
@@ -113,7 +120,7 @@ class MarkdownParser(DocumentParser):
 
         # Build breadcrumb: parent path parts + own heading (if not already the last parent part)
         if own_heading and (not parent_parts or parent_parts[-1] != own_heading):
-            parts = parent_parts + [own_heading]
+            parts = [*parent_parts, own_heading]
         elif parent_parts:
             parts = parent_parts
         else:

--- a/packages/guru-server/src/guru_server/main.py
+++ b/packages/guru-server/src/guru_server/main.py
@@ -10,8 +10,8 @@ from guru_server.app import create_app
 from guru_server.config import resolve_config
 from guru_server.embedding import OllamaEmbedder
 from guru_server.startup import (
-    check_ollama_installed,
     check_model_available,
+    check_ollama_installed,
     start_ollama_serve,
     stop_ollama_serve,
 )

--- a/packages/guru-server/src/guru_server/startup.py
+++ b/packages/guru-server/src/guru_server/startup.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-import os
 
 
 class OllamaNotFoundError(RuntimeError):
@@ -26,17 +25,18 @@ def check_model_available(model: str = "nomic-embed-text") -> None:
     try:
         result = subprocess.run(
             ["ollama", "list"],
-            capture_output=True, text=True, check=True,
+            capture_output=True,
+            text=True,
+            check=True,
         )
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError as exc:
         raise ModelNotFoundError(
             f"Could not list Ollama models. Is Ollama running?\n"
             f"Pull the model with: ollama pull {model}"
-        )
+        ) from exc
     if model not in result.stdout:
         raise ModelNotFoundError(
-            f"Model '{model}' is not available.\n"
-            f"Pull it with: ollama pull {model}"
+            f"Model '{model}' is not available.\nPull it with: ollama pull {model}"
         )
 
 
@@ -46,7 +46,12 @@ def start_ollama_serve() -> subprocess.Popen | None:
         return None
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         pass
-    return subprocess.Popen(["ollama", "serve"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+    return subprocess.Popen(
+        ["ollama", "serve"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
 
 
 def stop_ollama_serve(proc: subprocess.Popen | None) -> None:

--- a/packages/guru-server/src/guru_server/storage.py
+++ b/packages/guru-server/src/guru_server/storage.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
+
 import json
+
 import lancedb
+
 from guru_server.ingestion.base import Chunk
 
 VECTOR_DIM = 768
@@ -38,20 +41,22 @@ class VectorStore:
                     f"Vector at index {i} has dimension {len(vector)}, expected {VECTOR_DIM}"
                 )
         records = []
-        for i, (chunk, vector) in enumerate(zip(chunks, vectors)):
-            records.append({
-                "vector": vector,
-                "content": chunk.content,
-                "file_path": chunk.file_path,
-                "header_breadcrumb": chunk.header_breadcrumb,
-                "chunk_level": chunk.chunk_level,
-                "chunk_index": i,
-                "frontmatter": json.dumps(chunk.frontmatter),
-                "labels": json.dumps(chunk.labels),
-                "chunk_id": chunk.chunk_id or "",
-                "parent_chunk_id": chunk.parent_chunk_id or "",
-                "content_type": chunk.content_type,
-            })
+        for i, (chunk, vector) in enumerate(zip(chunks, vectors, strict=True)):
+            records.append(
+                {
+                    "vector": vector,
+                    "content": chunk.content,
+                    "file_path": chunk.file_path,
+                    "header_breadcrumb": chunk.header_breadcrumb,
+                    "chunk_level": chunk.chunk_level,
+                    "chunk_index": i,
+                    "frontmatter": json.dumps(chunk.frontmatter),
+                    "labels": json.dumps(chunk.labels),
+                    "chunk_id": chunk.chunk_id or "",
+                    "parent_chunk_id": chunk.parent_chunk_id or "",
+                    "content_type": chunk.content_type,
+                }
+            )
         table = self._get_table()
         if table is None:
             self._table = self.db.create_table(TABLE_NAME, data=records)
@@ -69,11 +74,7 @@ class VectorStore:
         table = self._get_table()
         if table is None:
             return 0
-        rows = (
-            table.search(None)
-            .select(["file_path"])
-            .to_list()
-        )
+        rows = table.search(None).select(["file_path"]).to_list()
         return len({r["file_path"] for r in rows})
 
     def delete_file(self, file_path: str) -> None:
@@ -91,7 +92,9 @@ class VectorStore:
         escaped = ", ".join(f"'{_escape_sql_string(fp)}'" for fp in file_paths)
         table.delete(f"file_path IN ({escaped})")
 
-    def search(self, query_vector: list[float], n_results: int = 10, where: str | None = None) -> list[dict]:
+    def search(
+        self, query_vector: list[float], n_results: int = 10, where: str | None = None
+    ) -> list[dict]:
         table = self._get_table()
         if table is None:
             return []
@@ -99,30 +102,35 @@ class VectorStore:
         if where:
             query = query.where(where)
         results = query.to_list()
-        return [{"content": r["content"], "file_path": r["file_path"],
-                 "header_breadcrumb": r["header_breadcrumb"], "chunk_level": r["chunk_level"],
-                 "labels": _parse_json_list(r["labels"]),
-                 "score": 1.0 / (1.0 + r.get("_distance", 0.0))} for r in results]
+        return [
+            {
+                "content": r["content"],
+                "file_path": r["file_path"],
+                "header_breadcrumb": r["header_breadcrumb"],
+                "chunk_level": r["chunk_level"],
+                "labels": _parse_json_list(r["labels"]),
+                "score": 1.0 / (1.0 + r.get("_distance", 0.0)),
+            }
+            for r in results
+        ]
 
     def list_documents(self) -> list[dict]:
         table = self._get_table()
         if table is None:
             return []
         # Project only needed columns to avoid loading large vector data
-        df = (
-            table.search(None)
-            .select(["file_path", "frontmatter", "labels"])
-            .to_pandas()
-        )
+        df = table.search(None).select(["file_path", "frontmatter", "labels"]).to_pandas()
         docs = []
         for file_path, group in df.groupby("file_path"):
             first_row = group.iloc[0]
-            docs.append({
-                "file_path": file_path,
-                "frontmatter": _parse_json_dict(first_row["frontmatter"]),
-                "labels": _parse_json_list(first_row["labels"]),
-                "chunk_count": len(group),
-            })
+            docs.append(
+                {
+                    "file_path": file_path,
+                    "frontmatter": _parse_json_dict(first_row["frontmatter"]),
+                    "labels": _parse_json_list(first_row["labels"]),
+                    "chunk_count": len(group),
+                }
+            )
         return docs
 
     def get_document(self, file_path: str) -> dict | None:

--- a/packages/guru-server/tests/test_api.py
+++ b/packages/guru-server/tests/test_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -11,7 +11,12 @@ def mock_store():
     store = MagicMock()
     store.chunk_count.return_value = 100
     store.list_documents.return_value = [
-        {"file_path": "specs/auth.md", "frontmatter": {"title": "Auth"}, "labels": ["spec"], "chunk_count": 5},
+        {
+            "file_path": "specs/auth.md",
+            "frontmatter": {"title": "Auth"},
+            "labels": ["spec"],
+            "chunk_count": 5,
+        },
     ]
     store.get_document.return_value = {
         "file_path": "specs/auth.md",
@@ -87,8 +92,18 @@ def test_list_documents(client):
 
 def test_list_documents_with_label_filter(client, mock_store):
     mock_store.list_documents.return_value = [
-        {"file_path": "specs/auth.md", "frontmatter": {"title": "Auth"}, "labels": ["spec"], "chunk_count": 5},
-        {"file_path": "specs/rbac.md", "frontmatter": {"title": "RBAC"}, "labels": ["spec", "security"], "chunk_count": 3},
+        {
+            "file_path": "specs/auth.md",
+            "frontmatter": {"title": "Auth"},
+            "labels": ["spec"],
+            "chunk_count": 5,
+        },
+        {
+            "file_path": "specs/rbac.md",
+            "frontmatter": {"title": "RBAC"},
+            "labels": ["spec", "security"],
+            "chunk_count": 3,
+        },
     ]
     resp = client.get("/documents?labels=security")
     assert resp.status_code == 200
@@ -138,7 +153,9 @@ def test_search(client):
 
 
 def test_search_with_filters(client):
-    resp = client.post("/search", json={"query": "auth", "n_results": 5, "filters": {"labels": "spec"}})
+    resp = client.post(
+        "/search", json={"query": "auth", "n_results": 5, "filters": {"labels": "spec"}}
+    )
     assert resp.status_code == 200
 
 

--- a/packages/guru-server/tests/test_config.py
+++ b/packages/guru-server/tests/test_config.py
@@ -3,15 +3,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
-from guru_core.types import Rule, MatchConfig
+from guru_core.types import MatchConfig, Rule
 from guru_server.config import DEFAULT_RULES, load_rules, merge_rules, resolve_config
-
 
 # ---------------------------------------------------------------------------
 # DEFAULT_RULES
 # ---------------------------------------------------------------------------
+
 
 def test_default_rules_has_one_rule():
     assert len(DEFAULT_RULES) == 1
@@ -29,11 +27,10 @@ def test_default_rules_glob():
 # load_rules
 # ---------------------------------------------------------------------------
 
+
 def test_load_rules_from_json(tmp_path: Path):
     config_file = tmp_path / "rules.json"
-    config_file.write_text(json.dumps([
-        {"ruleName": "docs", "match": {"glob": "docs/**/*.md"}}
-    ]))
+    config_file.write_text(json.dumps([{"ruleName": "docs", "match": {"glob": "docs/**/*.md"}}]))
     rules = load_rules(config_file)
     assert rules is not None
     assert len(rules) == 1
@@ -50,6 +47,7 @@ def test_load_rules_returns_none_for_missing_file(tmp_path: Path):
 # ---------------------------------------------------------------------------
 # merge_rules
 # ---------------------------------------------------------------------------
+
 
 def test_merge_rules_local_overrides_global():
     global_rules = [Rule(rule_name="default", match=MatchConfig(glob="**/*.md"))]
@@ -72,6 +70,7 @@ def test_merge_rules_local_appends_new_rules():
 # resolve_config
 # ---------------------------------------------------------------------------
 
+
 def test_resolve_config_prefers_guru_json(tmp_path: Path):
     project_root = tmp_path / "project"
     project_root.mkdir()
@@ -79,15 +78,15 @@ def test_resolve_config_prefers_guru_json(tmp_path: Path):
     global_dir.mkdir()
 
     # Create guru.json (preferred)
-    (project_root / "guru.json").write_text(json.dumps([
-        {"ruleName": "preferred", "match": {"glob": "preferred/**"}}
-    ]))
+    (project_root / "guru.json").write_text(
+        json.dumps([{"ruleName": "preferred", "match": {"glob": "preferred/**"}}])
+    )
     # Also create .guru/config.json (fallback, should be ignored)
     guru_dir = project_root / ".guru"
     guru_dir.mkdir()
-    (guru_dir / "config.json").write_text(json.dumps([
-        {"ruleName": "fallback", "match": {"glob": "fallback/**"}}
-    ]))
+    (guru_dir / "config.json").write_text(
+        json.dumps([{"ruleName": "fallback", "match": {"glob": "fallback/**"}}])
+    )
 
     rules = resolve_config(project_root, global_config_dir=global_dir)
     names = {r.rule_name for r in rules}
@@ -103,9 +102,9 @@ def test_resolve_config_falls_back_to_guru_config_json(tmp_path: Path):
 
     guru_dir = project_root / ".guru"
     guru_dir.mkdir()
-    (guru_dir / "config.json").write_text(json.dumps([
-        {"ruleName": "fallback", "match": {"glob": "fallback/**"}}
-    ]))
+    (guru_dir / "config.json").write_text(
+        json.dumps([{"ruleName": "fallback", "match": {"glob": "fallback/**"}}])
+    )
 
     rules = resolve_config(project_root, global_config_dir=global_dir)
     names = {r.rule_name for r in rules}
@@ -118,12 +117,12 @@ def test_resolve_config_merges_with_global(tmp_path: Path):
     global_dir = tmp_path / "global"
     global_dir.mkdir()
 
-    (global_dir / "config.json").write_text(json.dumps([
-        {"ruleName": "global-rule", "match": {"glob": "global/**"}}
-    ]))
-    (project_root / "guru.json").write_text(json.dumps([
-        {"ruleName": "local-rule", "match": {"glob": "local/**"}}
-    ]))
+    (global_dir / "config.json").write_text(
+        json.dumps([{"ruleName": "global-rule", "match": {"glob": "global/**"}}])
+    )
+    (project_root / "guru.json").write_text(
+        json.dumps([{"ruleName": "local-rule", "match": {"glob": "local/**"}}])
+    )
 
     rules = resolve_config(project_root, global_config_dir=global_dir)
     names = {r.rule_name for r in rules}

--- a/packages/guru-server/tests/test_embedding.py
+++ b/packages/guru-server/tests/test_embedding.py
@@ -1,5 +1,4 @@
 import httpx
-import pytest
 
 from guru_server.embedding import OllamaEmbedder
 
@@ -15,6 +14,7 @@ class TestOllamaEmbedder:
         monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
 
         import asyncio
+
         embedder = OllamaEmbedder(base_url="http://localhost:11434")
         result = asyncio.run(embedder.embed("hello world"))
         assert len(result) == 768
@@ -32,6 +32,7 @@ class TestOllamaEmbedder:
         monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
 
         import asyncio
+
         embedder = OllamaEmbedder(base_url="http://localhost:11434")
         results = asyncio.run(embedder.embed_batch(["hello", "world"]))
         assert len(results) == 2

--- a/packages/guru-server/tests/test_ingestion.py
+++ b/packages/guru-server/tests/test_ingestion.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import tempfile
 from pathlib import Path
 
 import pytest
 
 from guru_core.types import ChunkingConfig, MatchConfig, Rule
 from guru_server.ingestion import Chunk, DocumentParser, MarkdownParser
-
 
 SAMPLE_MD = """\
 ---
@@ -110,6 +108,7 @@ def chunks(parser: MarkdownParser, md_file: Path, rule: Rule) -> list[Chunk]:
 
 # --- Chunk dataclass ---
 
+
 def test_chunk_construction():
     chunk = Chunk(
         content="hello",
@@ -146,11 +145,13 @@ def test_chunk_with_all_fields():
 
 # --- MarkdownParser isinstance ---
 
+
 def test_markdown_parser_is_document_parser(parser: MarkdownParser):
     assert isinstance(parser, DocumentParser)
 
 
 # --- supports() ---
+
 
 def test_supports_md(parser: MarkdownParser, tmp_path: Path):
     assert parser.supports(tmp_path / "file.md") is True
@@ -166,6 +167,7 @@ def test_not_supports_txt(parser: MarkdownParser, tmp_path: Path):
 
 # --- parse() basic ---
 
+
 def test_parse_returns_list(chunks: list[Chunk]):
     assert isinstance(chunks, list)
     assert len(chunks) > 0
@@ -178,6 +180,7 @@ def test_parse_returns_chunks(chunks: list[Chunk]):
 
 # --- Frontmatter extraction ---
 
+
 def test_frontmatter_extracted(chunks: list[Chunk]):
     for chunk in chunks:
         assert chunk.frontmatter.get("title") == "API Guide"
@@ -185,6 +188,7 @@ def test_frontmatter_extracted(chunks: list[Chunk]):
 
 
 # --- Header breadcrumbs ---
+
 
 def test_chunk_breadcrumbs_present(chunks: list[Chunk]):
     breadcrumbs = [c.header_breadcrumb for c in chunks]
@@ -205,11 +209,13 @@ def test_nested_breadcrumb_format(chunks: list[Chunk]):
     # Token Refresh is nested under Authentication, so its breadcrumb should have ' > '
     token_refresh_chunks = [c for c in chunks if "Token Refresh" in c.header_breadcrumb]
     assert token_refresh_chunks, "Expected at least one chunk with 'Token Refresh' in breadcrumb"
-    assert any(" > " in c.header_breadcrumb for c in token_refresh_chunks), \
+    assert any(" > " in c.header_breadcrumb for c in token_refresh_chunks), (
         f"Expected ' > ' in breadcrumb, got: {[c.header_breadcrumb for c in token_refresh_chunks]}"
+    )
 
 
 # --- Labels ---
+
 
 def test_labels_from_rule(chunks: list[Chunk], rule: Rule):
     for chunk in chunks:
@@ -223,12 +229,14 @@ def test_labels_content(chunks: list[Chunk]):
 
 # --- file_path ---
 
+
 def test_file_path_set(chunks: list[Chunk], md_file: Path):
     for chunk in chunks:
         assert chunk.file_path == str(md_file)
 
 
 # --- chunk_id ---
+
 
 def test_chunk_id_set(chunks: list[Chunk]):
     for chunk in chunks:
@@ -243,12 +251,14 @@ def test_chunk_ids_unique(chunks: list[Chunk]):
 
 # --- chunk_level ---
 
+
 def test_chunk_level_range(chunks: list[Chunk]):
     for chunk in chunks:
         assert 1 <= chunk.chunk_level <= 3
 
 
 # --- content_type detection ---
+
 
 def test_content_type_default_is_text(chunks: list[Chunk]):
     # SAMPLE_MD has no code blocks or tables
@@ -288,6 +298,7 @@ def test_content_type_mixed(parser: MarkdownParser, tmp_path: Path, rule: Rule):
 
 # --- parent_chunk_id ---
 
+
 def test_parent_chunk_id_set_on_h3_chunks(parser: MarkdownParser, tmp_path: Path, rule: Rule):
     p = tmp_path / "deep.md"
     p.write_text(SAMPLE_MD_WITH_H3, encoding="utf-8")
@@ -297,11 +308,13 @@ def test_parent_chunk_id_set_on_h3_chunks(parser: MarkdownParser, tmp_path: Path
     assert l3_chunks, "Expected level-3 chunks from h3 headers"
     assert l2_chunks, "Expected level-2 chunks from h2 headers"
     for c in l3_chunks:
-        assert c.parent_chunk_id is not None, \
+        assert c.parent_chunk_id is not None, (
             f"Expected parent_chunk_id on level-3 chunk '{c.header_breadcrumb}'"
+        )
         parent_ids = {c2.chunk_id for c2 in l2_chunks}
-        assert c.parent_chunk_id in parent_ids, \
+        assert c.parent_chunk_id in parent_ids, (
             f"parent_chunk_id '{c.parent_chunk_id}' not in level-2 chunk IDs {parent_ids}"
+        )
 
 
 def test_l2_chunks_have_no_parent(parser: MarkdownParser, tmp_path: Path, rule: Rule):
@@ -310,11 +323,13 @@ def test_l2_chunks_have_no_parent(parser: MarkdownParser, tmp_path: Path, rule: 
     result = parser.parse(p, rule)
     l2_chunks = [c for c in result if c.chunk_level == 2]
     for c in l2_chunks:
-        assert c.parent_chunk_id is None, \
+        assert c.parent_chunk_id is None, (
             f"Level-2 chunk '{c.header_breadcrumb}' should not have a parent"
+        )
 
 
 # --- chunking.split_level ---
+
 
 def test_split_level_h2_merges_h3_into_parent(parser: MarkdownParser, tmp_path: Path):
     rule_h2 = Rule(
@@ -327,13 +342,15 @@ def test_split_level_h2_merges_h3_into_parent(parser: MarkdownParser, tmp_path: 
     p.write_text(SAMPLE_MD_WITH_H3, encoding="utf-8")
     result = parser.parse(p, rule_h2)
     l3_chunks = [c for c in result if c.chunk_level == 3]
-    assert l3_chunks == [], \
+    assert l3_chunks == [], (
         f"Expected no level-3 chunks when split_level='h2', but found: {[c.header_breadcrumb for c in l3_chunks]}"
+    )
     # h3 content should be absorbed into h2 parent
     section_a = [c for c in result if "Section A" in c.header_breadcrumb]
     assert section_a, "Expected a 'Section A' level-2 chunk"
-    assert any("Sub A1" in c.content or "Sub-section A1" in c.content for c in section_a), \
+    assert any("Sub A1" in c.content or "Sub-section A1" in c.content for c in section_a), (
         "Expected Sub A1 content merged into Section A chunk"
+    )
 
 
 def test_split_level_h3_keeps_all_levels(parser: MarkdownParser, tmp_path: Path):
@@ -350,7 +367,9 @@ def test_split_level_h3_keeps_all_levels(parser: MarkdownParser, tmp_path: Path)
     assert l3_chunks, "Expected level-3 chunks when split_level='h3'"
 
 
-def test_max_tokens_stored_as_metadata(parser: MarkdownParser, tmp_path: Path, chunks: list[Chunk]):
+def test_max_tokens_stored_as_metadata(
+    parser: MarkdownParser, tmp_path: Path, chunks: list[Chunk]
+):
     # max_tokens is Phase 2 work; just verify the parse call doesn't blow up
     # and that chunks still have content
     assert all(c.content for c in chunks)

--- a/packages/guru-server/tests/test_startup.py
+++ b/packages/guru-server/tests/test_startup.py
@@ -1,13 +1,13 @@
 import subprocess
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from guru_server.startup import (
-    check_ollama_installed,
-    check_model_available,
-    OllamaNotFoundError,
     ModelNotFoundError,
+    OllamaNotFoundError,
+    check_model_available,
+    check_ollama_installed,
 )
 
 
@@ -17,9 +17,11 @@ def test_check_ollama_installed_success():
 
 
 def test_check_ollama_installed_not_found():
-    with patch("shutil.which", return_value=None):
-        with pytest.raises(OllamaNotFoundError, match="brew install ollama"):
-            check_ollama_installed()
+    with (
+        patch("shutil.which", return_value=None),
+        pytest.raises(OllamaNotFoundError, match="brew install ollama"),
+    ):
+        check_ollama_installed()
 
 
 def test_check_model_available_success():
@@ -32,12 +34,16 @@ def test_check_model_available_success():
 def test_check_model_available_not_found():
     mock_result = MagicMock()
     mock_result.stdout = "llama3:latest\tsome-hash\t4.7 GB"
-    with patch("subprocess.run", return_value=mock_result):
-        with pytest.raises(ModelNotFoundError, match="ollama pull nomic-embed-text"):
-            check_model_available("nomic-embed-text")
+    with (
+        patch("subprocess.run", return_value=mock_result),
+        pytest.raises(ModelNotFoundError, match="ollama pull nomic-embed-text"),
+    ):
+        check_model_available("nomic-embed-text")
 
 
 def test_check_model_available_ollama_not_running():
-    with patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "ollama")):
-        with pytest.raises(ModelNotFoundError):
-            check_model_available("nomic-embed-text")
+    with (
+        patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "ollama")),
+        pytest.raises(ModelNotFoundError),
+    ):
+        check_model_available("nomic-embed-text")

--- a/packages/guru-server/tests/test_storage.py
+++ b/packages/guru-server/tests/test_storage.py
@@ -1,46 +1,72 @@
 import pytest
-from guru_server.storage import VectorStore
+
 from guru_server.ingestion.base import Chunk
+from guru_server.storage import VectorStore
+
 
 @pytest.fixture
 def store(tmp_path):
     return VectorStore(db_path=str(tmp_path / "db"))
 
+
 @pytest.fixture
 def sample_chunks():
     return [
-        Chunk(content="OAuth 2.0 authentication flow", file_path="specs/auth.md",
-              header_breadcrumb="Auth > OAuth", chunk_level=2,
-              frontmatter={"title": "Auth Spec", "status": "approved"},
-              labels=["spec"], chunk_id="abc123", content_type="text"),
-        Chunk(content="Token refresh happens every 30 minutes", file_path="specs/auth.md",
-              header_breadcrumb="Auth > OAuth > Token Refresh", chunk_level=3,
-              frontmatter={"title": "Auth Spec", "status": "approved"},
-              labels=["spec"], chunk_id="def456", content_type="text"),
-        Chunk(content="Role-based access control for API endpoints", file_path="specs/rbac.md",
-              header_breadcrumb="RBAC > API Access", chunk_level=2,
-              frontmatter={"title": "RBAC Spec", "status": "draft"},
-              labels=["spec", "security"], chunk_id="ghi789", content_type="text"),
+        Chunk(
+            content="OAuth 2.0 authentication flow",
+            file_path="specs/auth.md",
+            header_breadcrumb="Auth > OAuth",
+            chunk_level=2,
+            frontmatter={"title": "Auth Spec", "status": "approved"},
+            labels=["spec"],
+            chunk_id="abc123",
+            content_type="text",
+        ),
+        Chunk(
+            content="Token refresh happens every 30 minutes",
+            file_path="specs/auth.md",
+            header_breadcrumb="Auth > OAuth > Token Refresh",
+            chunk_level=3,
+            frontmatter={"title": "Auth Spec", "status": "approved"},
+            labels=["spec"],
+            chunk_id="def456",
+            content_type="text",
+        ),
+        Chunk(
+            content="Role-based access control for API endpoints",
+            file_path="specs/rbac.md",
+            header_breadcrumb="RBAC > API Access",
+            chunk_level=2,
+            frontmatter={"title": "RBAC Spec", "status": "draft"},
+            labels=["spec", "security"],
+            chunk_id="ghi789",
+            content_type="text",
+        ),
     ]
+
 
 def test_add_and_count(store, sample_chunks):
     fake_vectors = [[0.1] * 768 for _ in sample_chunks]
     store.add_chunks(sample_chunks, fake_vectors)
     assert store.chunk_count() == 3
 
+
 def test_add_chunks_length_mismatch(store, sample_chunks):
     with pytest.raises(ValueError, match="same length"):
         store.add_chunks(sample_chunks, [[0.1] * 768])
 
+
 def test_add_chunks_wrong_vector_dim(store, sample_chunks):
     with pytest.raises(ValueError, match="dimension"):
         store.add_chunks(sample_chunks[:1], [[0.1] * 100])
+
 
 def test_document_count(store, sample_chunks):
     assert store.document_count() == 0
     fake_vectors = [[0.1] * 768 for _ in sample_chunks]
     store.add_chunks(sample_chunks, fake_vectors)
     assert store.document_count() == 2
+
 
 def test_search_returns_results(store, sample_chunks):
     fake_vectors = [[0.1] * 768 for _ in sample_chunks]
@@ -49,12 +75,16 @@ def test_search_returns_results(store, sample_chunks):
     assert len(results) == 2
     assert all("file_path" in r for r in results)
 
+
 def test_search_with_label_filter(store, sample_chunks):
     fake_vectors = [[0.1] * 768 for _ in sample_chunks]
     store.add_chunks(sample_chunks, fake_vectors)
-    results = store.search(query_vector=[0.1] * 768, n_results=10, where="labels LIKE '%security%'")
+    results = store.search(
+        query_vector=[0.1] * 768, n_results=10, where="labels LIKE '%security%'"
+    )
     assert len(results) >= 1
     assert all("security" in r.get("labels", []) for r in results)
+
 
 def test_list_documents(store, sample_chunks):
     fake_vectors = [[0.1] * 768 for _ in sample_chunks]
@@ -64,6 +94,7 @@ def test_list_documents(store, sample_chunks):
     assert "specs/auth.md" in file_paths
     assert "specs/rbac.md" in file_paths
 
+
 def test_get_document(store, sample_chunks):
     fake_vectors = [[0.1] * 768 for _ in sample_chunks]
     store.add_chunks(sample_chunks, fake_vectors)
@@ -71,6 +102,7 @@ def test_get_document(store, sample_chunks):
     assert doc is not None
     assert doc["file_path"] == "specs/auth.md"
     assert doc["chunk_count"] == 2
+
 
 def test_get_document_stable_order(store, sample_chunks):
     """Re-indexing should return chunks in ingestion order."""
@@ -83,9 +115,11 @@ def test_get_document_stable_order(store, sample_chunks):
     doc2 = store.get_document("specs/auth.md")
     assert doc1["content"] == doc2["content"]
 
+
 def test_get_document_not_found(store):
     doc = store.get_document("nonexistent.md")
     assert doc is None
+
 
 def test_get_section(store, sample_chunks):
     fake_vectors = [[0.1] * 768 for _ in sample_chunks]
@@ -93,6 +127,7 @@ def test_get_section(store, sample_chunks):
     section = store.get_section("specs/auth.md", "Auth > OAuth > Token Refresh")
     assert section is not None
     assert "Token refresh" in section["content"]
+
 
 def test_delete_files_prevents_duplicates(store, sample_chunks):
     """Re-indexing should not duplicate chunks."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,28 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-xdist>=3.8.0",
+    "ruff>=0.11",
 ]
+
+[tool.ruff]
+target-version = "py313"
+line-length = 99
+src = ["packages/guru-core/src", "packages/guru-server/src", "packages/guru-mcp/src", "packages/guru-cli/src"]
+
+[tool.ruff.lint]
+select = [
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "F",     # pyflakes
+    "I",     # isort
+    "UP",    # pyupgrade
+    "B",     # flake8-bugbear
+    "SIM",   # flake8-simplify
+    "RUF",   # ruff-specific rules
+]
+ignore = [
+    "E501",  # line length handled by formatter
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["guru_core", "guru_server", "guru_mcp", "guru_cli"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,43 @@
 [project]
 name = "guru"
-version = "0.1.0"
+dynamic = ["version", "dependencies"]
 description = "Local-first knowledge base manager with MCP interface"
 requires-python = ">=3.13"
-dependencies = []
+
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.hatch.metadata.hooks.uv-dynamic-versioning]
+dependencies = [
+    "guru-core=={{ version }}",
+    "guru-server=={{ version }}",
+    "guru-mcp=={{ version }}",
+    "guru-cli=={{ version }}",
+]
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/guru"]
+
+[tool.hatch.build.targets.sdist]
+include = ["pyproject.toml", "src/"]
 
 [tool.uv.workspace]
 members = ["packages/*"]
+
+[tool.uv.sources]
+guru-core = { workspace = true }
+guru-server = { workspace = true }
+guru-mcp = { workspace = true }
+guru-cli = { workspace = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -53,9 +53,7 @@ def generate_index(wheels_dir: Path, output_dir: Path) -> None:
         root_links.append(f'<a href="{name}/">{name}</a>')
 
     (output_dir / "index.html").write_text(
-        "<!DOCTYPE html>\n<html><body>\n"
-        + "\n".join(root_links)
-        + "\n</body></html>\n"
+        "<!DOCTYPE html>\n<html><body>\n" + "\n".join(root_links) + "\n</body></html>\n"
     )
 
     # Generate per-package index
@@ -66,9 +64,7 @@ def generate_index(wheels_dir: Path, output_dir: Path) -> None:
         for whl in sorted(wheels):
             links.append(f'<a href="../../wheels/{whl}">{whl}</a>')
         (pkg_dir / "index.html").write_text(
-            "<!DOCTYPE html>\n<html><body>\n"
-            + "\n".join(links)
-            + "\n</body></html>\n"
+            "<!DOCTYPE html>\n<html><body>\n" + "\n".join(links) + "\n</body></html>\n"
         )
 
 

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Generate a PEP 503 simple repository index from a directory of wheels.
+
+Usage: python scripts/generate-index.py <wheels-dir> <output-dir>
+
+Scans <wheels-dir> for .whl files and generates a PEP 503-compliant simple
+repository index in <output-dir>/. Package directories use normalized names
+(lowercase, hyphens). Links point to ../../wheels/<filename>.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# PEP 503: normalize by lowercasing and replacing runs of [_.-] with a single hyphen
+_NORMALIZE_RE = re.compile(r"[-_.]+")
+
+
+def _normalize(name: str) -> str:
+    return _NORMALIZE_RE.sub("-", name).lower()
+
+
+def _parse_wheel_name(filename: str) -> str | None:
+    """Extract the distribution name from a wheel filename.
+
+    Wheel filenames follow: {name}-{version}(-{build})?-{python}-{abi}-{platform}.whl
+    """
+    parts = filename.split("-")
+    if len(parts) < 3:
+        return None
+    return parts[0]
+
+
+def generate_index(wheels_dir: Path, output_dir: Path) -> None:
+    """Generate PEP 503 simple index from wheels directory."""
+    wheel_files = sorted(wheels_dir.glob("*.whl"))
+
+    # Group wheels by normalized package name
+    packages: dict[str, list[str]] = {}
+    for whl in wheel_files:
+        raw_name = _parse_wheel_name(whl.name)
+        if raw_name is None:
+            continue
+        norm = _normalize(raw_name)
+        packages.setdefault(norm, []).append(whl.name)
+
+    # Generate root index
+    output_dir.mkdir(parents=True, exist_ok=True)
+    root_links = []
+    for name in sorted(packages):
+        root_links.append(f'<a href="{name}/">{name}</a>')
+
+    (output_dir / "index.html").write_text(
+        "<!DOCTYPE html>\n<html><body>\n"
+        + "\n".join(root_links)
+        + "\n</body></html>\n"
+    )
+
+    # Generate per-package index
+    for name, wheels in sorted(packages.items()):
+        pkg_dir = output_dir / name
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        links = []
+        for whl in sorted(wheels):
+            links.append(f'<a href="../../wheels/{whl}">{whl}</a>')
+        (pkg_dir / "index.html").write_text(
+            "<!DOCTYPE html>\n<html><body>\n"
+            + "\n".join(links)
+            + "\n</body></html>\n"
+        )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <wheels-dir> <output-dir>", file=sys.stderr)
+        sys.exit(1)
+    generate_index(Path(sys.argv[1]), Path(sys.argv[2]))
+    print(f"Index generated in {sys.argv[2]}")

--- a/scripts/test-generate-index.py
+++ b/scripts/test-generate-index.py
@@ -1,0 +1,63 @@
+"""Tests for the PEP 503 simple index generator."""
+
+import sys
+from pathlib import Path
+
+# Allow importing the script from the same directory
+sys.path.insert(0, str(Path(__file__).parent))
+
+import pytest
+from generate_index import generate_index
+
+
+@pytest.fixture
+def wheel_dir(tmp_path):
+    """Create a fake wheels directory with sample wheel files."""
+    wheels = tmp_path / "wheels"
+    wheels.mkdir()
+    # Create fake wheel files (content doesn't matter, just filenames)
+    (wheels / "guru-0.1.0-py3-none-any.whl").touch()
+    (wheels / "guru_core-0.1.0-py3-none-any.whl").touch()
+    (wheels / "guru_server-0.1.0-py3-none-any.whl").touch()
+    (wheels / "guru_mcp-0.1.0-py3-none-any.whl").touch()
+    (wheels / "guru_cli-0.1.0-py3-none-any.whl").touch()
+    return wheels
+
+
+def test_generates_root_index(wheel_dir, tmp_path):
+    simple = tmp_path / "simple"
+    generate_index(wheel_dir, simple)
+    root_html = (simple / "index.html").read_text()
+    assert '<a href="guru/">guru</a>' in root_html
+    assert '<a href="guru-core/">guru-core</a>' in root_html
+    assert '<a href="guru-server/">guru-server</a>' in root_html
+    assert '<a href="guru-mcp/">guru-mcp</a>' in root_html
+    assert '<a href="guru-cli/">guru-cli</a>' in root_html
+
+
+def test_generates_package_index(wheel_dir, tmp_path):
+    simple = tmp_path / "simple"
+    generate_index(wheel_dir, simple)
+    guru_html = (simple / "guru" / "index.html").read_text()
+    assert "guru-0.1.0-py3-none-any.whl" in guru_html
+    # Check the href points to the wheels directory
+    assert "../../wheels/guru-0.1.0-py3-none-any.whl" in guru_html
+
+
+def test_multiple_versions(wheel_dir, tmp_path):
+    (wheel_dir / "guru-0.2.0-py3-none-any.whl").touch()
+    simple = tmp_path / "simple"
+    generate_index(wheel_dir, simple)
+    guru_html = (simple / "guru" / "index.html").read_text()
+    assert "guru-0.1.0-py3-none-any.whl" in guru_html
+    assert "guru-0.2.0-py3-none-any.whl" in guru_html
+
+
+def test_normalized_package_names(wheel_dir, tmp_path):
+    """Wheel filenames use underscores but PEP 503 dirs use hyphens."""
+    simple = tmp_path / "simple"
+    generate_index(wheel_dir, simple)
+    # guru_core wheel -> guru-core directory
+    assert (simple / "guru-core" / "index.html").is_file()
+    core_html = (simple / "guru-core" / "index.html").read_text()
+    assert "guru_core-0.1.0-py3-none-any.whl" in core_html

--- a/src/guru/__init__.py
+++ b/src/guru/__init__.py
@@ -1,0 +1,1 @@
+# Meta-package: installs guru-core, guru-server, guru-mcp, guru-cli

--- a/tests/e2e/features/environment.py
+++ b/tests/e2e/features/environment.py
@@ -17,7 +17,6 @@ from guru_server.config import resolve_config
 from guru_server.embedding import OllamaEmbedder
 from guru_server.storage import VectorStore
 
-
 # ---------------------------------------------------------------------------
 # Project directory builders
 # ---------------------------------------------------------------------------
@@ -331,9 +330,7 @@ def before_feature(context, feature):
         context.project_dir = _create_standard_project()
         context.embedder = _make_fake_embedder()
 
-    context.server, context.server_thread = _start_server(
-        context.project_dir, context.embedder
-    )
+    context.server, context.server_thread = _start_server(context.project_dir, context.embedder)
 
 
 def after_feature(context, feature):

--- a/tests/e2e/features/steps/cli_steps.py
+++ b/tests/e2e/features/steps/cli_steps.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 from pathlib import Path
 
-from behave import given, when, then
-
+from behave import given, then, when
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -112,7 +110,7 @@ def step_list_and_pick(context, fragment):
             context.picked_path = line.strip().split(" ")[0]
             return
 
-    assert False, f"'{fragment}' not found in list output:\n{out}"
+    raise AssertionError(f"'{fragment}' not found in list output:\n{out}")
 
 
 @when('I get the document containing "{fragment}"')
@@ -126,9 +124,7 @@ def step_get_doc_containing(context, fragment):
         if fragment in line:
             doc_path = line.strip().split(" ")[0]
             break
-    assert doc_path is not None, (
-        f"No document containing '{fragment}' in list output:\n{list_out}"
-    )
+    assert doc_path is not None, f"No document containing '{fragment}' in list output:\n{list_out}"
 
     code, out = _run_cli(["doc", doc_path], cwd=context.project_dir)
     context.last_exit_code = code
@@ -149,9 +145,7 @@ def step_command_succeeds(context):
 
 @then('the output contains "{text}"')
 def step_output_contains(context, text):
-    assert text in context.last_output, (
-        f"Expected '{text}' in output:\n{context.last_output}"
-    )
+    assert text in context.last_output, f"Expected '{text}' in output:\n{context.last_output}"
 
 
 @then('the output does not contain "{text}"')
@@ -188,8 +182,7 @@ def step_first_result_contains_alternatives(context, alternatives):
 
     matched = [kw for kw in keywords if kw.lower() in first_text]
     assert matched, (
-        f"First result does not contain any of {keywords}.\n"
-        f"First result text:\n{first_text}"
+        f"First result does not contain any of {keywords}.\nFirst result text:\n{first_text}"
     )
 
 
@@ -216,13 +209,9 @@ def step_search_results_contain_label(context, label):
             file_path = line.replace("File:", "").strip()
             break
 
-    assert file_path is not None, (
-        f"No file path found in search output:\n{context.last_output}"
-    )
+    assert file_path is not None, f"No file path found in search output:\n{context.last_output}"
 
     # Get the document JSON and check label
     code, out = _run_cli(["doc", file_path], cwd=context.project_dir)
     assert code == 0, f"Failed to get doc {file_path}:\n{out}"
-    assert label in out, (
-        f"Label '{label}' not found in document for {file_path}:\n{out}"
-    )
+    assert label in out, f"Label '{label}' not found in document for {file_path}:\n{out}"

--- a/tests/e2e/features/steps/mcp_steps.py
+++ b/tests/e2e/features/steps/mcp_steps.py
@@ -10,12 +10,11 @@ import asyncio
 import json
 from unittest.mock import patch
 
-from behave import given, when, then
-
+from behave import given, then, when
 from fastmcp import Client
+
 from guru_core.client import GuruClient
 from guru_mcp.server import mcp
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -91,7 +90,7 @@ def step_find_doc_path(context, fragment):
         if fragment in doc["file_path"]:
             context.known_file_path = doc["file_path"]
             return
-    assert False, f"No document matching '{fragment}' found in: {docs}"
+    raise AssertionError(f"No document matching '{fragment}' found in: {docs}")
 
 
 @given('I know a section header containing "{fragment}"')
@@ -110,7 +109,7 @@ def step_find_section_header(context, fragment):
             context.known_header = r["header_breadcrumb"]
             return
     breadcrumbs = [r.get("header_breadcrumb", "") for r in results]
-    assert False, f"No header containing '{fragment}'. Available: {breadcrumbs}"
+    raise AssertionError(f"No header containing '{fragment}'. Available: {breadcrumbs}")
 
 
 # ---------------------------------------------------------------------------
@@ -133,9 +132,7 @@ def step_call_mcp_no_args(context, tool_name):
 def step_call_mcp_search(context, tool_name, query):
     """Call an MCP search tool with a query."""
     try:
-        context.mcp_result = _run(
-            _call_tool(context.mcp_client, tool_name, {"query": query})
-        )
+        context.mcp_result = _run(_call_tool(context.mcp_client, tool_name, {"query": query}))
         context.mcp_error = None
     except Exception as e:
         context.mcp_result = None
@@ -155,14 +152,12 @@ def step_call_mcp_search_limited(context, tool_name, query, n):
         context.mcp_error = e
 
 
-@when("I call MCP tool \"get_document\" with the known file path")
+@when('I call MCP tool "get_document" with the known file path')
 def step_call_mcp_get_document(context):
     """Call get_document with the file path found in a previous step."""
     try:
         context.mcp_result = _run(
-            _call_tool(
-                context.mcp_client, "get_document", {"file_path": context.known_file_path}
-            )
+            _call_tool(context.mcp_client, "get_document", {"file_path": context.known_file_path})
         )
         context.mcp_error = None
     except Exception as e:
@@ -170,7 +165,7 @@ def step_call_mcp_get_document(context):
         context.mcp_error = e
 
 
-@when("I call MCP tool \"get_section\" with the known file path and header")
+@when('I call MCP tool "get_section" with the known file path and header')
 def step_call_mcp_get_section(context):
     """Call get_section with file path and header from previous steps."""
     try:
@@ -222,21 +217,15 @@ def step_mcp_result_nonempty_list(context):
     assert len(context.mcp_result) > 0, "MCP result list is empty"
 
 
-@then('the MCP result is a list with {n:d} items')
+@then("the MCP result is a list with {n:d} items")
 def step_mcp_result_list_count(context, n):
-    assert isinstance(context.mcp_result, list), (
-        f"Expected list, got {type(context.mcp_result)}"
-    )
-    assert len(context.mcp_result) == n, (
-        f"Expected {n} items, got {len(context.mcp_result)}"
-    )
+    assert isinstance(context.mcp_result, list), f"Expected list, got {type(context.mcp_result)}"
+    assert len(context.mcp_result) == n, f"Expected {n} items, got {len(context.mcp_result)}"
 
 
-@then('the MCP result has at most {n:d} items')
+@then("the MCP result has at most {n:d} items")
 def step_mcp_result_at_most(context, n):
-    assert isinstance(context.mcp_result, list), (
-        f"Expected list, got {type(context.mcp_result)}"
-    )
+    assert isinstance(context.mcp_result, list), f"Expected list, got {type(context.mcp_result)}"
     assert len(context.mcp_result) <= n, (
         f"Expected at most {n} items, got {len(context.mcp_result)}"
     )
@@ -277,18 +266,14 @@ def step_mcp_result_field_contains(context, field, text):
     actual = context.mcp_result.get(field)
     assert actual is not None, f"Field '{field}' is None"
     actual_str = str(actual)
-    assert text in actual_str, (
-        f"Expected '{text}' in {field}, got: {actual_str[:200]}"
-    )
+    assert text in actual_str, f"Expected '{text}' in {field}, got: {actual_str[:200]}"
 
 
 @then('the first MCP result has field "{field}"')
 def step_first_mcp_result_has_field(context, field):
     assert isinstance(context.mcp_result, list) and len(context.mcp_result) > 0
     first = context.mcp_result[0]
-    assert field in first, (
-        f"Field '{field}' not in first result. Keys: {list(first.keys())}"
-    )
+    assert field in first, f"Field '{field}' not in first result. Keys: {list(first.keys())}"
 
 
 @then('the first MCP result field "{field}" contains "{text}"')
@@ -305,14 +290,10 @@ def step_some_result_has_label(context, label):
     assert isinstance(context.mcp_result, list), "Result is not a list"
     for item in context.mcp_result:
         labels = item.get("labels", [])
-        if isinstance(labels, str):
-            if label in labels:
-                return
-        elif isinstance(labels, list):
-            if label in labels:
-                return
+        if isinstance(labels, str | list) and label in labels:
+            return
     all_labels = [item.get("labels") for item in context.mcp_result]
-    assert False, f"No result has label '{label}'. Labels found: {all_labels}"
+    raise AssertionError(f"No result has label '{label}'. Labels found: {all_labels}")
 
 
 @then('the MCP result contains an item with file_path matching "{fragment}"')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 """Integration smoke test: init -> index -> search without real Ollama."""
+
 import json
 
 import pytest
@@ -19,9 +20,13 @@ def project(tmp_path):
 
     # Config
     config = tmp_path / "guru.json"
-    config.write_text(json.dumps([
-        {"ruleName": "default", "match": {"glob": "**/*.md"}},
-    ]))
+    config.write_text(
+        json.dumps(
+            [
+                {"ruleName": "default", "match": {"glob": "**/*.md"}},
+            ]
+        )
+    )
 
     # Sample docs
     docs = tmp_path / "docs"

--- a/uv.lock
+++ b/uv.lock
@@ -784,8 +784,13 @@ wheels = [
 
 [[package]]
 name = "guru"
-version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
+dependencies = [
+    { name = "guru-cli" },
+    { name = "guru-core" },
+    { name = "guru-mcp" },
+    { name = "guru-server" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -793,9 +798,16 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "guru-cli", editable = "packages/guru-cli" },
+    { name = "guru-core", editable = "packages/guru-core" },
+    { name = "guru-mcp", editable = "packages/guru-mcp" },
+    { name = "guru-server", editable = "packages/guru-server" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -803,11 +815,11 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "ruff", specifier = ">=0.11" },
 ]
 
 [[package]]
 name = "guru-cli"
-version = "0.1.0"
 source = { editable = "packages/guru-cli" }
 dependencies = [
     { name = "click" },
@@ -836,7 +848,6 @@ dev = [
 
 [[package]]
 name = "guru-core"
-version = "0.1.0"
 source = { editable = "packages/guru-core" }
 dependencies = [
     { name = "httpx" },
@@ -863,7 +874,6 @@ dev = [
 
 [[package]]
 name = "guru-mcp"
-version = "0.1.0"
 source = { editable = "packages/guru-mcp" }
 dependencies = [
     { name = "fastmcp" },
@@ -890,7 +900,6 @@ dev = [
 
 [[package]]
 name = "guru-server"
-version = "0.1.0"
 source = { editable = "packages/guru-server" }
 dependencies = [
     { name = "fastapi" },
@@ -2347,6 +2356,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
     { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
     { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Switch all 5 packages from `uv_build` to `hatchling` + `uv-dynamic-versioning` for automatic git-tag-based versioning
- Convert root `guru` package to a meta-package that pulls in all sub-packages
- Add PEP 503 simple index generator and GitHub Actions release workflow for GitHub Pages distribution
- Enhance `guru init` to generate `.mcp.json` and `.gitignore` entries
- Rewrite README for end users, move dev docs to CONTRIBUTING.md
- Add Makefile with all project targets (test, build, lint, format)
- Add ruff linter/formatter with pre-commit hooks
- Add Claude Code PostToolUse hooks for auto-formatting Python files

## Install UX (after first release)

```bash
uv tool install guru --extra-index-url https://martinmacak.github.io/guru/simple/
cd my-markdown-repo
guru init
```

## Test plan

- [x] All 106 unit/integration tests pass
- [x] All 5 wheels build successfully (`make build`)
- [x] PEP 503 index generates correctly (`make build-index`)
- [x] `make lint` passes (ruff check + format)
- [x] pre-commit hooks pass on all commits
- [x] Tag a test release and verify CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)