### PR TITLE
fix: Add console_scripts to root meta-package for uv tool install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,11 @@ dynamic = ["version", "dependencies"]
 description = "Local-first knowledge base manager with MCP interface"
 requires-python = ">=3.13"
 
+[project.scripts]
+guru = "guru_cli.cli:cli"
+guru-server = "guru_server.main:main"
+guru-mcp = "guru_mcp.server:main"
+
 [build-system]
 requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,22 @@
+"""Verify the root meta-package exposes console-script entry points.
+
+Without these, `uv tool install guru` fails with
+"No executables are provided by package `guru`".
+"""
+
+import importlib.metadata
+
+
+def test_guru_package_has_console_scripts():
+    """Root 'guru' package must declare console_scripts so uv tool install works."""
+    eps = importlib.metadata.entry_points()
+    # Filter for the guru distribution's console_scripts
+    guru_scripts = [
+        ep
+        for ep in eps.select(group="console_scripts")
+        if ep.dist is not None and ep.dist.name == "guru"
+    ]
+    script_names = {ep.name for ep in guru_scripts}
+    assert "guru" in script_names, "Missing 'guru' console script in root package"
+    assert "guru-server" in script_names, "Missing 'guru-server' console script in root package"
+    assert "guru-mcp" in script_names, "Missing 'guru-mcp' console script in root package"


### PR DESCRIPTION
## Summary

- Root `guru` meta-package was missing `[project.scripts]`, causing `uv tool install guru` to fail with "No executables are provided by package `guru`"
- Added console_scripts re-exporting entry points from sub-packages (`guru`, `guru-server`, `guru-mcp`)
- Added packaging test to verify the root package declares all expected console scripts

Closes #9

## Test plan

- [x] New `test_guru_package_has_console_scripts` test verifies root package metadata includes all three entry points
- [x] Full test suite passes (107 tests)
- [ ] Manual verification: `uv tool install guru --extra-index-url ...` after next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)