### PR TITLE
fix: Surface server startup errors instead of generic timeout

### DIFF
--- a/packages/guru-core/src/guru_core/autostart.py
+++ b/packages/guru-core/src/guru_core/autostart.py
@@ -48,14 +48,17 @@ def ensure_server(guru_root: Path, timeout: float = 5.0) -> None:
     # Clean up stale state
     _cleanup_stale(guru_dir)
 
-    # Start server
+    # Start server, capturing stderr to a log file for diagnostics
     env = os.environ.copy()
     env["GURU_PROJECT_ROOT"] = str(guru_root)
 
-    subprocess.Popen(
+    log_path = guru_dir / "server.log"
+    log_file = open(log_path, "w")  # noqa: SIM115
+
+    proc = subprocess.Popen(
         ["guru-server"],
         stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stderr=log_file,
         start_new_session=True,
         env=env,
     )
@@ -65,17 +68,36 @@ def ensure_server(guru_root: Path, timeout: float = 5.0) -> None:
     last_error: Exception | None = None
 
     while time.monotonic() < deadline:
+        # Detect early process exit before waiting for the full timeout
+        if proc.poll() is not None:
+            log_file.close()
+            log_tail = _read_log_tail(log_path)
+            raise ServerStartError(f"guru-server exited with code {proc.returncode}.\n{log_tail}")
+
         if sock_file.exists():
             last_error = _health_check(str(sock_file))
             if last_error is None:
+                log_file.close()
                 return
         time.sleep(0.1)
 
+    log_file.close()
+    log_tail = _read_log_tail(log_path)
     detail = f": {last_error}" if last_error is not None else ""
-    raise ServerStartError(
-        f"guru-server did not start within {timeout}s{detail}. "
-        f"Check server logs or run `guru server start` manually."
-    )
+    raise ServerStartError(f"guru-server did not start within {timeout}s{detail}.\n{log_tail}")
+
+
+def _read_log_tail(log_path: Path, max_lines: int = 20) -> str:
+    """Read the last N lines of the server log for error reporting."""
+    try:
+        text = log_path.read_text().strip()
+        if not text:
+            return "Server log is empty."
+        lines = text.splitlines()
+        tail = lines[-max_lines:]
+        return "Server log:\n" + "\n".join(tail)
+    except OSError:
+        return "Server log not available."
 
 
 def _health_check(sock_path: str) -> Exception | None:

--- a/packages/guru-core/tests/test_client.py
+++ b/packages/guru-core/tests/test_client.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -102,8 +103,9 @@ class TestEnsureServer:
 
         monkeypatch.setattr("os.kill", fake_kill)
 
-        # Mock subprocess to "start" the server
+        # Mock subprocess to "start" the server (process stays alive)
         mock_popen = MagicMock()
+        mock_popen.poll.return_value = None
         monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: mock_popen)
 
         # Mock socket check to succeed after start
@@ -139,8 +141,10 @@ class TestEnsureServer:
             "os.kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
         )
 
-        # Mock subprocess
-        monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: MagicMock())
+        # Mock subprocess (process stays alive)
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: mock_proc)
 
         # Socket always appears immediately
         original_exists = Path.exists
@@ -182,3 +186,90 @@ class TestEnsureServer:
 
         result = _health_check("/fake/guru.sock")
         assert isinstance(result, httpx.ConnectError)
+
+    def test_early_exit_includes_server_log(self, tmp_path, monkeypatch):
+        """When the server process exits early, the error includes server log content."""
+        guru_dir = tmp_path / ".guru"
+        guru_dir.mkdir()
+        pid_file = guru_dir / "guru.pid"
+        pid_file.write_text("99999")
+
+        # No existing server
+        monkeypatch.setattr(
+            "os.kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
+        )
+
+        # Fake Popen that exits immediately with an error
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1  # process exited with code 1
+
+        def fake_popen(*args, **kwargs):
+            # Write error message to the log file (simulating stderr redirect)
+            log_file = kwargs.get("stderr")
+            if log_file and hasattr(log_file, "write"):
+                log_file.write("OllamaNotFoundError: Ollama is not installed or not on PATH.\n")
+                log_file.flush()
+            return mock_proc
+
+        monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+        with pytest.raises(ServerStartError, match="Ollama is not installed"):
+            ensure_server(tmp_path, timeout=0.5)
+
+    def test_early_exit_detected_before_timeout(self, tmp_path, monkeypatch):
+        """Early process exit is detected quickly, not after the full timeout."""
+        import time
+
+        guru_dir = tmp_path / ".guru"
+        guru_dir.mkdir()
+        pid_file = guru_dir / "guru.pid"
+        pid_file.write_text("99999")
+
+        monkeypatch.setattr(
+            "os.kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
+        )
+
+        # Process that exits immediately
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+
+        monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: mock_proc)
+
+        start = time.monotonic()
+        with pytest.raises(ServerStartError):
+            ensure_server(tmp_path, timeout=5.0)
+        elapsed = time.monotonic() - start
+
+        # Should detect early exit well before the 5s timeout
+        assert elapsed < 2.0, f"Took {elapsed:.1f}s — should detect early exit quickly"
+
+    def test_server_log_written_to_guru_dir(self, tmp_path, monkeypatch):
+        """Server stderr is redirected to .guru/server.log."""
+        guru_dir = tmp_path / ".guru"
+        guru_dir.mkdir()
+        pid_file = guru_dir / "guru.pid"
+        pid_file.write_text("99999")
+
+        monkeypatch.setattr(
+            "os.kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
+        )
+
+        captured_kwargs = {}
+
+        def fake_popen(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = 1
+            return mock_proc
+
+        monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+        with pytest.raises(ServerStartError):
+            ensure_server(tmp_path, timeout=0.3)
+
+        # Verify stderr was directed to a file in .guru/
+        stderr_target = captured_kwargs.get("stderr")
+        assert stderr_target is not None
+        assert stderr_target != subprocess.DEVNULL
+        assert hasattr(stderr_target, "name")  # it's a file object
+        assert "server.log" in stderr_target.name


### PR DESCRIPTION
## Summary

Closes #12.

- `ensure_server()` was swallowing all server stderr (`DEVNULL`) and discarding the `Popen` reference, making it impossible to diagnose why the server failed to start
- Now redirects stderr to `.guru/server.log`, detects early process exit via `proc.poll()`, and includes the server log content in the `ServerStartError` message
- Early crashes (e.g., Ollama not installed) are detected immediately instead of waiting the full 5s timeout

**Before:** `guru-server did not start within 5.0s. Check server logs or run guru server start manually.`

**After:** `guru-server exited with code 1. Server log: OllamaNotFoundError: Ollama is not installed or not on PATH.`

## Test plan

- [x] 3 new unit tests for early-exit detection, log capture, and fast failure
- [x] All 110 existing tests pass with no regressions
- [x] Manual test: `guru server start` works on a configured machine
- [x] Manual test: `.guru/server.log` is created and captures server output

🤖 Generated with [Claude Code](https://claude.com/claude-code)