### PR TITLE
fix: Set explicit read timeout on GuruClient and add server logging infrastructure

### DIFF
--- a/docs/superpowers/plans/2026-04-10-server-logging.md
+++ b/docs/superpowers/plans/2026-04-10-server-logging.md
@@ -1,0 +1,1111 @@
+# Server Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add proper Python logging infrastructure to the guru server so errors are always visible and diagnosable.
+
+**Architecture:** A shared `setup_logging()` function in guru-core configures Python's standard `logging` module with a stderr handler (always) and an optional `RotatingFileHandler`. The server process owns its logging via CLI args (`--log-level`, `--log-file`). Autostart passes these args to the daemon subprocess. The CLI gains `--foreground` mode for interactive debugging.
+
+**Tech Stack:** Python `logging` (stdlib), `logging.handlers.RotatingFileHandler`, `argparse`, `click`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `packages/guru-core/src/guru_core/log.py` | New — `setup_logging()` function |
+| `packages/guru-core/tests/test_log.py` | New — tests for `setup_logging()` |
+| `packages/guru-core/src/guru_core/client.py` | Add DEBUG logging to HTTP calls |
+| `packages/guru-core/src/guru_core/autostart.py` | Pass `--log-file`/`--log-level` args, append-mode stderr |
+| `packages/guru-core/tests/test_client.py` | Update autostart tests |
+| `packages/guru-server/src/guru_server/main.py` | Parse CLI args, call `setup_logging()`, configure uvicorn |
+| `packages/guru-server/src/guru_server/startup.py` | Add INFO logging |
+| `packages/guru-server/src/guru_server/embedding.py` | Add DEBUG/ERROR logging |
+| `packages/guru-server/src/guru_server/storage.py` | Add WARNING/ERROR logging |
+| `packages/guru-server/src/guru_server/api/index.py` | Add INFO/ERROR logging with timing |
+| `packages/guru-cli/src/guru_cli/cli.py` | Add `--foreground`, `--log-file`, `--log-level` flags |
+
+---
+
+### Task 1: Create `setup_logging()` in guru-core
+
+**Files:**
+- Create: `packages/guru-core/src/guru_core/log.py`
+- Create: `packages/guru-core/tests/test_log.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/guru-core/tests/test_log.py`:
+
+```python
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from guru_core.log import setup_logging
+
+LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+
+class TestSetupLogging:
+    @pytest.fixture(autouse=True)
+    def reset_root_logger(self):
+        """Remove all handlers added during a test."""
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_level = root.level
+        yield
+        root.handlers = original_handlers
+        root.level = original_level
+
+    def test_default_level_is_info(self):
+        setup_logging()
+        root = logging.getLogger()
+        assert root.level == logging.INFO
+
+    def test_level_override(self):
+        setup_logging(level="DEBUG")
+        root = logging.getLogger()
+        assert root.level == logging.DEBUG
+
+    def test_stderr_handler_always_added(self):
+        setup_logging()
+        root = logging.getLogger()
+        stream_handlers = [
+            h for h in root.handlers if isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.FileHandler)
+        ]
+        assert len(stream_handlers) == 1
+
+    def test_file_handler_added_when_log_file_provided(self, tmp_path):
+        log_file = str(tmp_path / "test.log")
+        setup_logging(log_file=log_file)
+        root = logging.getLogger()
+        from logging.handlers import RotatingFileHandler
+        file_handlers = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+        assert len(file_handlers) == 1
+        assert file_handlers[0].maxBytes == 10 * 1024 * 1024
+        assert file_handlers[0].backupCount == 3
+
+    def test_no_file_handler_when_log_file_not_provided(self):
+        setup_logging()
+        root = logging.getLogger()
+        file_handlers = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+        assert len(file_handlers) == 0
+
+    def test_log_format(self):
+        setup_logging()
+        root = logging.getLogger()
+        handler = root.handlers[-1]
+        assert handler.formatter._fmt == LOG_FORMAT
+
+    def test_writes_to_log_file(self, tmp_path):
+        log_file = tmp_path / "test.log"
+        setup_logging(level="INFO", log_file=str(log_file))
+        logger = logging.getLogger("test.writes")
+        logger.info("hello from test")
+        # Flush handlers
+        for h in logging.getLogger().handlers:
+            h.flush()
+        content = log_file.read_text()
+        assert "hello from test" in content
+
+    def test_env_var_fallback(self, monkeypatch):
+        monkeypatch.setenv("GURU_LOG_LEVEL", "WARNING")
+        setup_logging()
+        root = logging.getLogger()
+        assert root.level == logging.WARNING
+
+    def test_explicit_level_overrides_env_var(self, monkeypatch):
+        monkeypatch.setenv("GURU_LOG_LEVEL", "WARNING")
+        setup_logging(level="DEBUG")
+        root = logging.getLogger()
+        assert root.level == logging.DEBUG
+
+    def test_idempotent_no_duplicate_handlers(self):
+        setup_logging()
+        setup_logging()
+        root = logging.getLogger()
+        stream_handlers = [
+            h for h in root.handlers if isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.FileHandler)
+        ]
+        assert len(stream_handlers) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest packages/guru-core/tests/test_log.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'guru_core.log'`
+
+- [ ] **Step 3: Write implementation**
+
+Create `packages/guru-core/src/guru_core/log.py`:
+
+```python
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from logging.handlers import RotatingFileHandler
+
+LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+_GURU_HANDLER_ATTR = "_guru_logging"
+
+
+def setup_logging(
+    level: str | None = None,
+    log_file: str | None = None,
+    max_bytes: int = 10 * 1024 * 1024,
+    backup_count: int = 3,
+) -> None:
+    """Configure logging for all guru packages.
+
+    Args:
+        level: Log level name (DEBUG, INFO, WARNING, ERROR).
+               Falls back to GURU_LOG_LEVEL env var, then INFO.
+        log_file: Optional path for a RotatingFileHandler.
+        max_bytes: Max log file size before rotation (default 10MB).
+        backup_count: Number of rotated files to keep (default 3).
+    """
+    root = logging.getLogger()
+
+    # Remove any handlers we previously added (idempotent)
+    root.handlers = [h for h in root.handlers if not getattr(h, _GURU_HANDLER_ATTR, False)]
+
+    # Resolve level: explicit arg > env var > INFO
+    if level is None:
+        level = os.environ.get("GURU_LOG_LEVEL", "INFO")
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+    formatter = logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT)
+
+    # Always add stderr handler
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(formatter)
+    setattr(stderr_handler, _GURU_HANDLER_ATTR, True)
+    root.addHandler(stderr_handler)
+
+    # Optionally add rotating file handler
+    if log_file:
+        file_handler = RotatingFileHandler(
+            log_file, maxBytes=max_bytes, backupCount=backup_count
+        )
+        file_handler.setFormatter(formatter)
+        setattr(file_handler, _GURU_HANDLER_ATTR, True)
+        root.addHandler(file_handler)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest packages/guru-core/tests/test_log.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/guru-core/src/guru_core/log.py packages/guru-core/tests/test_log.py
+git commit -m "feat(guru-core): Add setup_logging() with stderr and rotating file handler"
+```
+
+---
+
+### Task 2: Add CLI args to `guru-server` and integrate logging
+
+**Files:**
+- Modify: `packages/guru-server/src/guru_server/main.py`
+- Modify: `packages/guru-server/tests/` (if existing main tests need updating)
+
+- [ ] **Step 1: Write failing test**
+
+Add to a new file `packages/guru-server/tests/test_main.py`:
+
+```python
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+
+class TestMainArgParsing:
+    @pytest.fixture(autouse=True)
+    def reset_root_logger(self):
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_level = root.level
+        yield
+        root.handlers = original_handlers
+        root.level = original_level
+
+    def test_parse_log_level_flag(self):
+        from guru_server.main import _parse_args
+
+        args = _parse_args(["--log-level", "DEBUG"])
+        assert args.log_level == "DEBUG"
+
+    def test_parse_log_file_flag(self):
+        from guru_server.main import _parse_args
+
+        args = _parse_args(["--log-file", "/tmp/test.log"])
+        assert args.log_file == "/tmp/test.log"
+
+    def test_default_log_level_is_none(self):
+        from guru_server.main import _parse_args
+
+        args = _parse_args([])
+        assert args.log_level is None
+
+    def test_default_log_file_is_none(self):
+        from guru_server.main import _parse_args
+
+        args = _parse_args([])
+        assert args.log_file is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest packages/guru-server/tests/test_main.py -v`
+Expected: FAIL — `ImportError: cannot import name '_parse_args' from 'guru_server.main'`
+
+- [ ] **Step 3: Add arg parsing and logging to main.py**
+
+Modify `packages/guru-server/src/guru_server/main.py`. The full new content:
+
+```python
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+import uvicorn
+
+from guru_core.log import LOG_FORMAT, DATE_FORMAT, setup_logging
+from guru_server.app import create_app
+from guru_server.config import resolve_config
+from guru_server.embedding import OllamaEmbedder
+from guru_server.startup import (
+    check_model_available,
+    check_ollama_installed,
+    start_ollama_serve,
+    stop_ollama_serve,
+)
+from guru_server.storage import VectorStore
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Guru knowledge-base server")
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default=None,
+        help="Log level (default: INFO, overrides GURU_LOG_LEVEL env var)",
+    )
+    parser.add_argument(
+        "--log-file",
+        default=None,
+        help="Path to log file (enables rotating file handler)",
+    )
+    return parser.parse_args(argv)
+
+
+def _uvicorn_log_config(formatter_fmt: str, date_fmt: str) -> dict:
+    """Build a uvicorn log_config that reuses our log format."""
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {"fmt": formatter_fmt, "datefmt": date_fmt},
+            "access": {"fmt": formatter_fmt, "datefmt": date_fmt},
+        },
+        "handlers": {
+            "default": {
+                "class": "logging.StreamHandler",
+                "formatter": "default",
+                "stream": "ext://sys.stderr",
+            },
+            "access": {
+                "class": "logging.StreamHandler",
+                "formatter": "access",
+                "stream": "ext://sys.stderr",
+            },
+        },
+        "loggers": {
+            "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
+            "uvicorn.error": {"level": "INFO"},
+            "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
+        },
+    }
+
+
+def main():
+    args = _parse_args()
+    setup_logging(level=args.log_level, log_file=args.log_file)
+
+    project_root = os.environ.get("GURU_PROJECT_ROOT", os.getcwd())
+    guru_dir = Path(project_root) / ".guru"
+
+    if not guru_dir.is_dir():
+        logger.error("%s does not exist. Run `guru init` first.", guru_dir)
+        sys.exit(1)
+
+    logger.info("Starting guru-server (project_root=%s)", project_root)
+
+    # Preflight checks + startup
+    check_ollama_installed()
+    ollama_proc = start_ollama_serve()
+    try:
+        check_model_available("nomic-embed-text")
+
+        config = resolve_config(project_root=Path(project_root))
+        store = VectorStore(db_path=str(guru_dir / "db"))
+        embedder = OllamaEmbedder()
+
+        app = create_app(
+            store=store,
+            embedder=embedder,
+            config=config,
+            project_root=project_root,
+        )
+
+        socket_path = str(guru_dir / "guru.sock")
+        pid_path = guru_dir / "guru.pid"
+
+        pid_path.write_text(str(os.getpid()))
+        logger.info("Listening on %s (PID %d)", socket_path, os.getpid())
+
+        try:
+            uvicorn.run(
+                app,
+                uds=socket_path,
+                log_config=_uvicorn_log_config(LOG_FORMAT, DATE_FORMAT),
+            )
+        finally:
+            pid_path.unlink(missing_ok=True)
+            Path(socket_path).unlink(missing_ok=True)
+            logger.info("Server shut down")
+    finally:
+        stop_ollama_serve(ollama_proc)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest packages/guru-server/tests/test_main.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest --tb=short -q`
+Expected: all pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/guru-server/src/guru_server/main.py packages/guru-server/tests/test_main.py
+git commit -m "feat(guru-server): Add --log-level/--log-file args and integrate setup_logging()"
+```
+
+---
+
+### Task 3: Update autostart to pass logging args
+
+**Files:**
+- Modify: `packages/guru-core/src/guru_core/autostart.py`
+- Modify: `packages/guru-core/tests/test_client.py` (autostart tests)
+
+- [ ] **Step 1: Write failing test**
+
+Add to `packages/guru-core/tests/test_client.py` in `TestEnsureServer`:
+
+```python
+def test_passes_log_file_arg_to_server(self, tmp_path, monkeypatch):
+    """ensure_server passes --log-file pointing to .guru/server.log."""
+    guru_dir = tmp_path / ".guru"
+    guru_dir.mkdir()
+    pid_file = guru_dir / "guru.pid"
+    pid_file.write_text("99999")
+
+    monkeypatch.setattr(
+        "os.kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
+    )
+
+    captured_args = {}
+
+    def fake_popen(*args, **kwargs):
+        captured_args["cmd"] = args[0] if args else kwargs.get("args")
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        return mock_proc
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    original_exists = Path.exists
+    call_count = 0
+
+    def fake_exists(self):
+        nonlocal call_count
+        if self.name == "guru.sock":
+            call_count += 1
+            return call_count > 1
+        return original_exists(self)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr("guru_core.autostart._health_check", lambda sock_path: None)
+
+    ensure_server(tmp_path)
+
+    cmd = captured_args["cmd"]
+    assert "--log-file" in cmd
+    log_file_idx = cmd.index("--log-file")
+    log_file_path = cmd[log_file_idx + 1]
+    assert log_file_path == str(guru_dir / "server.log")
+
+def test_passes_log_level_from_env(self, tmp_path, monkeypatch):
+    """ensure_server forwards GURU_LOG_LEVEL as --log-level arg."""
+    guru_dir = tmp_path / ".guru"
+    guru_dir.mkdir()
+    pid_file = guru_dir / "guru.pid"
+    pid_file.write_text("99999")
+
+    monkeypatch.setattr(
+        "os.kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
+    )
+    monkeypatch.setenv("GURU_LOG_LEVEL", "DEBUG")
+
+    captured_args = {}
+
+    def fake_popen(*args, **kwargs):
+        captured_args["cmd"] = args[0] if args else kwargs.get("args")
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        return mock_proc
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    original_exists = Path.exists
+    call_count = 0
+
+    def fake_exists(self):
+        nonlocal call_count
+        if self.name == "guru.sock":
+            call_count += 1
+            return call_count > 1
+        return original_exists(self)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr("guru_core.autostart._health_check", lambda sock_path: None)
+
+    ensure_server(tmp_path)
+
+    cmd = captured_args["cmd"]
+    assert "--log-level" in cmd
+    level_idx = cmd.index("--log-level")
+    assert cmd[level_idx + 1] == "DEBUG"
+
+def test_stderr_redirected_in_append_mode(self, tmp_path, monkeypatch):
+    """Daemon stderr goes to server.log in append mode (not truncate)."""
+    guru_dir = tmp_path / ".guru"
+    guru_dir.mkdir()
+    pid_file = guru_dir / "guru.pid"
+    pid_file.write_text("99999")
+
+    monkeypatch.setattr(
+        "os.kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
+    )
+
+    captured_kwargs = {}
+
+    def fake_popen(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        return mock_proc
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    original_exists = Path.exists
+    call_count = 0
+
+    def fake_exists(self):
+        nonlocal call_count
+        if self.name == "guru.sock":
+            call_count += 1
+            return call_count > 1
+        return original_exists(self)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr("guru_core.autostart._health_check", lambda sock_path: None)
+
+    ensure_server(tmp_path)
+
+    stderr_target = captured_kwargs.get("stderr")
+    assert stderr_target is not None
+    assert hasattr(stderr_target, "mode")
+    assert "a" in stderr_target.mode
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest packages/guru-core/tests/test_client.py::TestEnsureServer::test_passes_log_file_arg_to_server packages/guru-core/tests/test_client.py::TestEnsureServer::test_passes_log_level_from_env packages/guru-core/tests/test_client.py::TestEnsureServer::test_stderr_redirected_in_append_mode -v`
+Expected: FAIL
+
+- [ ] **Step 3: Update autostart.py**
+
+Modify `packages/guru-core/src/guru_core/autostart.py` — full `ensure_server` function. Key changes:
+- Build command list with `--log-file` and `--log-level` args
+- Open stderr log file in append mode (`"a"`)
+
+```python
+def ensure_server(guru_root: Path, timeout: float = 5.0) -> None:
+    """Ensure the guru server is running."""
+    guru_dir = guru_root / ".guru"
+    pid_file = guru_dir / "guru.pid"
+    sock_file = guru_dir / "guru.sock"
+
+    # Check if already running
+    if pid_file.exists() and sock_file.exists():
+        try:
+            pid = int(pid_file.read_text().strip())
+            if _is_pid_alive(pid):
+                return
+        except (ValueError, OSError):
+            pass
+
+    _cleanup_stale(guru_dir)
+
+    env = os.environ.copy()
+    env["GURU_PROJECT_ROOT"] = str(guru_root)
+
+    # Build server command with logging args
+    cmd = ["guru-server", "--log-file", str(guru_dir / "server.log")]
+    log_level = os.environ.get("GURU_LOG_LEVEL")
+    if log_level:
+        cmd.extend(["--log-level", log_level])
+
+    # Redirect stderr to server.log in append mode as safety net for early crashes
+    log_path = guru_dir / "server.log"
+    log_file = open(log_path, "a")  # noqa: SIM115
+
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=log_file,
+        start_new_session=True,
+        env=env,
+    )
+
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            log_file.close()
+            log_tail = _read_log_tail(log_path)
+            raise ServerStartError(
+                f"guru-server exited with code {proc.returncode}.\n{log_tail}"
+            )
+
+        if sock_file.exists():
+            last_error = _health_check(str(sock_file))
+            if last_error is None:
+                log_file.close()
+                return
+        time.sleep(0.1)
+
+    log_file.close()
+    log_tail = _read_log_tail(log_path)
+    detail = f": {last_error}" if last_error is not None else ""
+    raise ServerStartError(
+        f"guru-server did not start within {timeout}s{detail}.\n{log_tail}"
+    )
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `uv run pytest packages/guru-core/tests/test_client.py::TestEnsureServer::test_passes_log_file_arg_to_server packages/guru-core/tests/test_client.py::TestEnsureServer::test_passes_log_level_from_env packages/guru-core/tests/test_client.py::TestEnsureServer::test_stderr_redirected_in_append_mode -v`
+Expected: PASS
+
+- [ ] **Step 5: Fix any broken existing autostart tests**
+
+Some existing tests (e.g., `test_server_log_written_to_guru_dir`) may need updating because the `open` mode changed from `"w"` to `"a"` and the subprocess command now includes extra args. Run the full autostart test class and fix as needed:
+
+Run: `uv run pytest packages/guru-core/tests/test_client.py::TestEnsureServer -v`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/guru-core/src/guru_core/autostart.py packages/guru-core/tests/test_client.py
+git commit -m "feat(guru-core): Pass --log-file/--log-level to daemon, use append mode"
+```
+
+---
+
+### Task 4: Add logging to server modules
+
+**Files:**
+- Modify: `packages/guru-server/src/guru_server/api/index.py`
+- Modify: `packages/guru-server/src/guru_server/embedding.py`
+- Modify: `packages/guru-server/src/guru_server/storage.py`
+- Modify: `packages/guru-server/src/guru_server/startup.py`
+
+These are additive changes — adding `logger` calls to existing code. No behavior changes, so existing tests remain valid. Test by verifying all existing tests still pass.
+
+- [ ] **Step 1: Add logging to `api/index.py`**
+
+Add at top of file:
+
+```python
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+```
+
+Add at start of `trigger_index()`:
+
+```python
+logger.info("Indexing requested (path=%s)", body.path or "project root")
+t0 = time.monotonic()
+```
+
+After the `if all_chunks:` block, before the return:
+
+```python
+elapsed = time.monotonic() - t0
+logger.info(
+    "Indexing complete: %d chunks from %d documents in %.1fs",
+    len(all_chunks),
+    len({c.file_path for c in all_chunks}),
+    elapsed,
+)
+```
+
+Wrap `embed_batch` in a try/except to log errors:
+
+```python
+try:
+    vectors = await embedder.embed_batch(texts)
+except Exception:
+    logger.exception("Embedding failed during indexing")
+    raise
+```
+
+- [ ] **Step 2: Add logging to `embedding.py`**
+
+Add at top:
+
+```python
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+```
+
+In `embed()`, around the HTTP call:
+
+```python
+async def embed(self, text: str) -> list[float]:
+    logger.debug("Embedding text (length=%d)", len(text))
+    t0 = time.monotonic()
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{self.base_url}/api/embeddings",
+            json={"model": self.model, "prompt": text},
+            timeout=30.0,
+        )
+    if response.status_code != 200:
+        logger.error("Ollama embedding failed (%d): %s", response.status_code, response.text)
+        raise EmbeddingError(
+            f"Ollama embedding failed ({response.status_code}): {response.text}"
+        )
+    logger.debug("Embedding complete in %.2fs", time.monotonic() - t0)
+    return response.json()["embedding"]
+```
+
+Apply the same pattern to `embed_batch()`:
+
+```python
+async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+    logger.debug("Embedding batch of %d texts", len(texts))
+    t0 = time.monotonic()
+    async with httpx.AsyncClient() as client:
+        results = []
+        for i, text in enumerate(texts):
+            response = await client.post(
+                f"{self.base_url}/api/embeddings",
+                json={"model": self.model, "prompt": text},
+                timeout=30.0,
+            )
+            if response.status_code != 200:
+                logger.error(
+                    "Ollama embedding failed for text %d/%d (%d): %s",
+                    i + 1, len(texts), response.status_code, response.text,
+                )
+                raise EmbeddingError(
+                    f"Ollama embedding failed ({response.status_code}): {response.text}"
+                )
+            results.append(response.json()["embedding"])
+    logger.debug("Batch embedding complete: %d texts in %.2fs", len(texts), time.monotonic() - t0)
+    return results
+```
+
+- [ ] **Step 3: Add logging to `storage.py`**
+
+Add at top:
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+In `_get_table()`:
+
+```python
+def _get_table(self):
+    if self._table is None:
+        try:
+            self._table = self.db.open_table(TABLE_NAME)
+        except FileNotFoundError:
+            logger.warning("Table '%s' not found (no data indexed yet)", TABLE_NAME)
+            return None
+        except Exception as exc:
+            msg = str(exc).lower()
+            if any(phrase in msg for phrase in _TABLE_NOT_FOUND_PHRASES):
+                logger.warning("Table '%s' not found: %s", TABLE_NAME, exc)
+                return None
+            raise
+    return self._table
+```
+
+In `_parse_json_list()`:
+
+```python
+def _parse_json_list(value: str) -> list:
+    try:
+        result = json.loads(value)
+        return result if isinstance(result, list) else []
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Failed to parse JSON list: %.100s", value)
+        return []
+```
+
+In `_parse_json_dict()`:
+
+```python
+def _parse_json_dict(value: str) -> dict:
+    try:
+        result = json.loads(value)
+        return result if isinstance(result, dict) else {}
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Failed to parse JSON dict: %.100s", value)
+        return {}
+```
+
+- [ ] **Step 4: Add logging to `startup.py`**
+
+Add at top:
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+In `check_ollama_installed()`:
+
+```python
+def check_ollama_installed() -> None:
+    if shutil.which("ollama") is None:
+        raise OllamaNotFoundError(...)
+    logger.info("Ollama found on PATH")
+```
+
+In `check_model_available()`, after the check:
+
+```python
+    logger.info("Model '%s' is available", model)
+```
+
+In `start_ollama_serve()`:
+
+```python
+def start_ollama_serve() -> subprocess.Popen | None:
+    try:
+        subprocess.run(["ollama", "list"], capture_output=True, text=True, check=True, timeout=5)
+        logger.info("Ollama is already running")
+        return None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        pass
+    logger.info("Starting ollama serve")
+    return subprocess.Popen(...)
+```
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest --tb=short -q`
+Expected: all pass (logging additions don't change behavior)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/guru-server/src/guru_server/api/index.py packages/guru-server/src/guru_server/embedding.py packages/guru-server/src/guru_server/storage.py packages/guru-server/src/guru_server/startup.py
+git commit -m "feat(guru-server): Add structured logging to all server modules"
+```
+
+---
+
+### Task 5: Add DEBUG logging to guru-core client
+
+**Files:**
+- Modify: `packages/guru-core/src/guru_core/client.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `packages/guru-core/tests/test_client.py` in `TestGuruClient`:
+
+```python
+@pytest.mark.asyncio
+async def test_post_logs_request_at_debug(self, guru_root, monkeypatch, caplog):
+    """_post logs HTTP method, path, and response status at DEBUG level."""
+    fake_response = httpx.Response(200, json={"indexed": 5, "documents": 2})
+
+    async def fake_post(self, url, **kwargs):
+        return fake_response
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    client = GuruClient(guru_root=guru_root)
+    with caplog.at_level(logging.DEBUG, logger="guru_core.client"):
+        await client.trigger_index()
+
+    assert any("POST /index" in r.message for r in caplog.records)
+    assert any("200" in r.message for r in caplog.records)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest packages/guru-core/tests/test_client.py::TestGuruClient::test_post_logs_request_at_debug -v`
+Expected: FAIL — no log records matching
+
+- [ ] **Step 3: Add logging to client.py**
+
+Add at top of `client.py`:
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+Update `_get` and `_post` to log:
+
+```python
+async def _get(self, path: str) -> dict | list:
+    async with httpx.AsyncClient(
+        transport=self._transport(), timeout=self._timeout
+    ) as client:
+        logger.debug("GET %s", path)
+        resp = await client.get(f"http://localhost{path}")
+        logger.debug("GET %s -> %d", path, resp.status_code)
+        if resp.is_error:
+            resp.raise_for_status()
+        return resp.json()
+
+async def _post(self, path: str, json: dict) -> dict | list:
+    async with httpx.AsyncClient(
+        transport=self._transport(), timeout=self._timeout
+    ) as client:
+        logger.debug("POST %s", path)
+        resp = await client.post(f"http://localhost{path}", json=json)
+        logger.debug("POST %s -> %d", path, resp.status_code)
+        if resp.is_error:
+            resp.raise_for_status()
+        return resp.json()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest packages/guru-core/tests/test_client.py::TestGuruClient::test_post_logs_request_at_debug -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/guru-core/src/guru_core/client.py packages/guru-core/tests/test_client.py
+git commit -m "feat(guru-core): Add DEBUG logging to GuruClient HTTP calls"
+```
+
+---
+
+### Task 6: Add `--foreground`, `--log-file`, `--log-level` to CLI
+
+**Files:**
+- Modify: `packages/guru-cli/src/guru_cli/cli.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `packages/guru-cli/tests/test_cli_server.py`:
+
+```python
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from guru_cli.cli import cli
+
+
+class TestServerStartFlags:
+    def test_foreground_flag_accepted(self):
+        runner = CliRunner()
+        with patch("guru_cli.cli.find_guru_root") as mock_find, \
+             patch("guru_cli.cli._run_foreground") as mock_fg:
+            mock_find.return_value = "/tmp/fake"
+            result = runner.invoke(cli, ["server", "start", "--foreground"])
+            assert result.exit_code == 0 or mock_fg.called
+
+    def test_log_level_flag_accepted(self):
+        runner = CliRunner()
+        with patch("guru_cli.cli.find_guru_root") as mock_find, \
+             patch("guru_cli.cli.ensure_server"):
+            mock_find.return_value = "/tmp/fake"
+            result = runner.invoke(cli, ["server", "start", "--log-level", "DEBUG"])
+            # Should not error on unknown flag
+            assert "no such option" not in (result.output or "").lower()
+
+    def test_log_file_flag_accepted(self):
+        runner = CliRunner()
+        with patch("guru_cli.cli.find_guru_root") as mock_find, \
+             patch("guru_cli.cli.ensure_server"):
+            mock_find.return_value = "/tmp/fake"
+            result = runner.invoke(cli, ["server", "start", "--log-file", "/tmp/test.log"])
+            assert "no such option" not in (result.output or "").lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest packages/guru-cli/tests/test_cli_server.py -v`
+Expected: FAIL
+
+- [ ] **Step 3: Update the `server start` command**
+
+Modify `packages/guru-cli/src/guru_cli/cli.py`. Replace the `server_start` function:
+
+```python
+@server.command("start")
+@click.option("--foreground", is_flag=True, help="Run in foreground (no daemonization)")
+@click.option("--log-level", type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False), default=None, help="Log level")
+@click.option("--log-file", type=click.Path(), default=None, help="Log file path")
+def server_start(foreground, log_level, log_file):
+    """Start the guru server."""
+    try:
+        guru_root = find_guru_root(Path.cwd())
+    except GuruNotFoundError as e:
+        click.echo(str(e), err=True)
+        sys.exit(1)
+
+    if foreground:
+        _run_foreground(guru_root, log_level=log_level, log_file=log_file)
+    else:
+        ensure_server(guru_root, log_level=log_level)
+        click.echo("Server is running.")
+
+
+def _run_foreground(guru_root: Path, log_level: str | None = None, log_file: str | None = None):
+    """Run the server in the current process (foreground mode)."""
+    import os
+
+    os.environ["GURU_PROJECT_ROOT"] = str(guru_root)
+
+    from guru_server.main import main as server_main
+
+    # Build argv for the server's arg parser
+    argv = []
+    if log_level:
+        argv.extend(["--log-level", log_level])
+    if log_file:
+        argv.extend(["--log-file", log_file])
+
+    # Override sys.argv for argparse in server main
+    import sys as _sys
+    original_argv = _sys.argv
+    _sys.argv = ["guru-server"] + argv
+    try:
+        server_main()
+    finally:
+        _sys.argv = original_argv
+```
+
+Also update `ensure_server` call signature — it needs to accept `log_level`:
+
+This requires updating `ensure_server()` in autostart.py to accept an optional `log_level` parameter (in addition to the env var fallback). Update the signature:
+
+```python
+def ensure_server(guru_root: Path, timeout: float = 5.0, log_level: str | None = None) -> None:
+```
+
+And in the command building:
+
+```python
+    log_level_resolved = log_level or os.environ.get("GURU_LOG_LEVEL")
+    if log_level_resolved:
+        cmd.extend(["--log-level", log_level_resolved])
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest packages/guru-cli/tests/test_cli_server.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest --tb=short -q`
+Expected: all pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/guru-cli/src/guru_cli/cli.py packages/guru-core/src/guru_core/autostart.py
+git commit -m "feat(guru-cli): Add --foreground, --log-level, --log-file to server start"
+```
+
+---
+
+### Task 7: Final integration verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `uv run pytest --tb=short -q`
+Expected: all pass
+
+- [ ] **Step 2: Run linter**
+
+Run: `make lint`
+Expected: clean
+
+- [ ] **Step 3: Run formatter**
+
+Run: `make fmt`
+Expected: no changes (or auto-fixed)
+
+- [ ] **Step 4: Final commit if formatter changed anything**
+
+```bash
+git add -u
+git commit -m "chore: Format after logging changes"
+```

--- a/docs/superpowers/specs/2026-04-10-server-logging-design.md
+++ b/docs/superpowers/specs/2026-04-10-server-logging-design.md
@@ -1,0 +1,157 @@
+# Server Logging Design
+
+## Problem
+
+The guru server has no structured logging. Errors are silently swallowed, `server.log`
+is truncated on every restart, and there's no way to diagnose issues like the index
+timeout (#14). Running `guru server start` gives no visibility into what the server
+is doing.
+
+## Design
+
+### Logging Module — `guru_core.logging`
+
+A new module in guru-core providing a `setup_logging()` function that configures
+Python's standard `logging` for all guru packages.
+
+```python
+def setup_logging(
+    level: str = "INFO",
+    log_file: str | None = None,
+    max_bytes: int = 10 * 1024 * 1024,  # 10MB
+    backup_count: int = 3,
+) -> None
+```
+
+**Format:** `2026-04-10 14:23:01 [INFO] guru_server.api.index: Indexed 42 chunks`
+
+**Handlers:**
+- stderr always (via `StreamHandler`)
+- Optional `RotatingFileHandler` when `log_file` is provided (10MB, keep 3 backups)
+
+**Level resolution chain:** `INFO` (default) < `GURU_LOG_LEVEL` env var < `--log-level` CLI flag.
+
+This module lives in guru-core because all packages depend on it. Called once at
+process startup.
+
+### Server Startup Modes
+
+`guru server start` gains three new flags:
+
+| Flag | Description |
+|------|-------------|
+| `--foreground` | Run in current process, logs to stderr, Ctrl-C to stop |
+| `--log-file PATH` | Tee logs to file in addition to stderr |
+| `--log-level LEVEL` | Override `GURU_LOG_LEVEL` env var for this run |
+
+**Daemon mode** (default):
+- Autostart passes `--log-file .guru/server.log` and `--log-level` to the
+  `guru-server` subprocess via command-line args
+- The server process sets up `RotatingFileHandler` internally (10MB, keep 3)
+- Autostart no longer redirects stderr — the server owns its own logging
+- Logs survive restarts (append) and rotate automatically
+
+**Foreground mode** (`--foreground`):
+- Runs the server in the current process (no `subprocess.Popen`)
+- Logs visible in terminal via stderr
+- `--log-file` optionally tees to file
+
+This shifts log ownership from autostart to the server process itself.
+
+### `guru-server` CLI Arguments
+
+The `guru-server` entry point (in `main.py`) accepts:
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--log-level` | `INFO` | Log level (DEBUG, INFO, WARNING, ERROR) |
+| `--log-file` | None | Path to log file (enables RotatingFileHandler) |
+
+These are parsed in `main()` before calling `setup_logging()` and `uvicorn.run()`.
+The `GURU_LOG_LEVEL` env var is checked as fallback when `--log-level` is not passed.
+
+### Logging Throughout the Server
+
+Each module uses `logger = logging.getLogger(__name__)`.
+
+**guru-server modules:**
+
+| Module | Level | What |
+|--------|-------|------|
+| `api/index.py` | INFO | Indexing started (file count), completed (chunk/doc count, duration) |
+| `api/index.py` | ERROR | Embedding or storage failures |
+| `embedding.py` | DEBUG | Each embedding call (text length, timing) |
+| `embedding.py` | ERROR | Ollama failures |
+| `storage.py` | WARNING | JSON parse failures (currently silent) |
+| `storage.py` | ERROR | Table access failures (currently returns empty silently) |
+| `startup.py` | INFO | Ollama status, model availability |
+| `main.py` | INFO | Server starting, socket path, shutdown |
+
+**guru-core:**
+
+| Module | Level | What |
+|--------|-------|------|
+| `client.py` | DEBUG | HTTP method, path, response status |
+
+**Out of scope:** guru-mcp, guru-cli (thin clients, add later).
+
+### Uvicorn Log Integration
+
+Uvicorn's loggers (`uvicorn`, `uvicorn.error`, `uvicorn.access`) are configured to
+use the same format and handlers via `log_config` parameter in `uvicorn.run()`.
+
+- Access logs at INFO level
+- Uvicorn error logs at ERROR level
+- Same plain-text format as application logs
+
+### Autostart Changes
+
+`ensure_server()` in `guru_core/autostart.py`:
+
+- No longer opens `server.log` or redirects stderr
+- Passes `--log-file <guru_root>/.guru/server.log` and `--log-level` to the
+  `guru-server` subprocess command
+- Reads `GURU_LOG_LEVEL` env var and forwards it as `--log-level` arg
+- `_read_log_tail()` still works for startup error messages (file now managed by server)
+- The subprocess uses `stdout=subprocess.DEVNULL, stderr=log_file` where `log_file`
+  is `.guru/server.log` opened in **append mode** (`"a"`, not `"w"`). This catches
+  early crashes (before `setup_logging()` runs) and preserves logs across restarts.
+- Once `setup_logging()` runs inside the server, the `RotatingFileHandler` takes
+  over writing to the same file. The stderr fd becomes a passive safety net for
+  unexpected crashes only.
+
+### Storage Error Handling Fix
+
+`storage.py` currently swallows errors silently:
+- `_parse_json_list()` catches `json.JSONDecodeError` and returns `[]`
+- `_parse_json_dict()` catches `json.JSONDecodeError` and returns `{}`
+- `_get_table()` catches `FileNotFoundError` and general exceptions, returns `None`
+
+Fix: add `logger.warning()` / `logger.error()` calls before returning fallback values.
+The fallback behavior stays (don't crash the server on bad data), but errors become
+visible in logs.
+
+### Trade-off: Dual File Descriptors in Daemon Mode
+
+In daemon mode, `.guru/server.log` is opened twice: once by autostart (stderr redirect,
+append mode) and once by the server's `RotatingFileHandler`. After `setup_logging()` runs,
+all application logs go through the `RotatingFileHandler`. The stderr fd becomes idle — it
+only captures output from unexpected Python-level crashes (segfaults, unhandled C extension
+errors). When the `RotatingFileHandler` rotates the file, the stderr fd still points to
+the old file (now `server.log.1`). This is acceptable: the only scenario where this matters
+is a crash after rotation, which is rare and the output would still be in `server.log.1`.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `packages/guru-core/src/guru_core/log.py` | New — `setup_logging()` function |
+| `packages/guru-core/src/guru_core/autostart.py` | Stop stderr redirect, pass CLI args |
+| `packages/guru-core/src/guru_core/client.py` | Add DEBUG logging for HTTP calls |
+| `packages/guru-server/src/guru_server/main.py` | Parse args, call `setup_logging()`, configure uvicorn |
+| `packages/guru-server/src/guru_server/api/index.py` | Add INFO/ERROR logging |
+| `packages/guru-server/src/guru_server/embedding.py` | Add DEBUG/ERROR logging |
+| `packages/guru-server/src/guru_server/storage.py` | Add WARNING/ERROR logging |
+| `packages/guru-server/src/guru_server/startup.py` | Add INFO logging |
+| `packages/guru-cli/src/guru_cli/cli.py` | Add `--foreground`, `--log-file`, `--log-level` flags |
+| Tests | New tests for `setup_logging()`, updated autostart tests |

--- a/packages/guru-cli/src/guru_cli/cli.py
+++ b/packages/guru-cli/src/guru_cli/cli.py
@@ -123,15 +123,51 @@ def server():
 
 
 @server.command("start")
-def server_start():
+@click.option("--foreground", is_flag=True, help="Run in foreground (no daemonization)")
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
+    default=None,
+    help="Log level",
+)
+@click.option("--log-file", type=click.Path(), default=None, help="Log file path")
+def server_start(foreground, log_level, log_file):
     """Start the guru server."""
     try:
         guru_root = find_guru_root(Path.cwd())
     except GuruNotFoundError as e:
         click.echo(str(e), err=True)
         sys.exit(1)
-    ensure_server(guru_root)
-    click.echo("Server is running.")
+
+    if foreground:
+        _run_foreground(guru_root, log_level=log_level, log_file=log_file)
+    else:
+        ensure_server(guru_root, log_level=log_level)
+        click.echo("Server is running.")
+
+
+def _run_foreground(guru_root: Path, log_level: str | None = None, log_file: str | None = None):
+    """Run the server in the current process (foreground mode)."""
+    import os
+
+    os.environ["GURU_PROJECT_ROOT"] = str(guru_root)
+
+    # Build argv for the server's arg parser
+    argv = []
+    if log_level:
+        argv.extend(["--log-level", log_level])
+    if log_file:
+        argv.extend(["--log-file", log_file])
+
+    # Override sys.argv for argparse in server main
+    original_argv = sys.argv
+    sys.argv = ["guru-server", *argv]
+    try:
+        from guru_server.main import main as server_main
+
+        server_main()
+    finally:
+        sys.argv = original_argv
 
 
 @server.command("stop")

--- a/packages/guru-cli/src/guru_cli/cli.py
+++ b/packages/guru-cli/src/guru_cli/cli.py
@@ -142,7 +142,7 @@ def server_start(foreground, log_level, log_file):
     if foreground:
         _run_foreground(guru_root, log_level=log_level, log_file=log_file)
     else:
-        ensure_server(guru_root, log_level=log_level)
+        ensure_server(guru_root, log_level=log_level, log_file=log_file)
         click.echo("Server is running.")
 
 
@@ -152,22 +152,15 @@ def _run_foreground(guru_root: Path, log_level: str | None = None, log_file: str
 
     os.environ["GURU_PROJECT_ROOT"] = str(guru_root)
 
-    # Build argv for the server's arg parser
     argv = []
     if log_level:
         argv.extend(["--log-level", log_level])
     if log_file:
         argv.extend(["--log-file", log_file])
 
-    # Override sys.argv for argparse in server main
-    original_argv = sys.argv
-    sys.argv = ["guru-server", *argv]
-    try:
-        from guru_server.main import main as server_main
+    from guru_server.main import main as server_main
 
-        server_main()
-    finally:
-        sys.argv = original_argv
+    server_main(argv=argv)
 
 
 @server.command("stop")

--- a/packages/guru-cli/tests/test_cli_server.py
+++ b/packages/guru-cli/tests/test_cli_server.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from guru_cli.cli import cli
+
+
+class TestServerStartFlags:
+    def test_foreground_flag_accepted(self):
+        runner = CliRunner()
+        with (
+            patch("guru_cli.cli.find_guru_root") as mock_find,
+            patch("guru_cli.cli._run_foreground") as mock_fg,
+        ):
+            mock_find.return_value = "/tmp/fake"
+            runner.invoke(cli, ["server", "start", "--foreground"])
+            mock_fg.assert_called_once()
+
+    def test_log_level_flag_accepted(self):
+        runner = CliRunner()
+        with (
+            patch("guru_cli.cli.find_guru_root") as mock_find,
+            patch("guru_cli.cli.ensure_server"),
+        ):
+            mock_find.return_value = "/tmp/fake"
+            result = runner.invoke(cli, ["server", "start", "--log-level", "DEBUG"])
+            assert "no such option" not in (result.output or "").lower()
+
+    def test_log_file_flag_accepted(self):
+        runner = CliRunner()
+        with (
+            patch("guru_cli.cli.find_guru_root") as mock_find,
+            patch("guru_cli.cli.ensure_server"),
+        ):
+            mock_find.return_value = "/tmp/fake"
+            result = runner.invoke(cli, ["server", "start", "--log-file", "/tmp/test.log"])
+            assert "no such option" not in (result.output or "").lower()
+
+    def test_daemon_mode_passes_log_level_to_ensure_server(self):
+        runner = CliRunner()
+        with (
+            patch("guru_cli.cli.find_guru_root") as mock_find,
+            patch("guru_cli.cli.ensure_server") as mock_ensure,
+        ):
+            mock_find.return_value = "/tmp/fake"
+            runner.invoke(cli, ["server", "start", "--log-level", "DEBUG"])
+            mock_ensure.assert_called_once()
+            _, kwargs = mock_ensure.call_args
+            assert kwargs.get("log_level") == "DEBUG"

--- a/packages/guru-core/src/guru_core/__init__.py
+++ b/packages/guru-core/src/guru_core/__init__.py
@@ -7,6 +7,7 @@ from guru_core.config import (
     resolve_config,
 )
 from guru_core.discovery import GuruNotFoundError, find_guru_root
+from guru_core.log import setup_logging
 from guru_core.types import (
     ChunkingConfig,
     DocumentInfo,
@@ -48,4 +49,5 @@ __all__ = [
     "load_rules",
     "merge_rules",
     "resolve_config",
+    "setup_logging",
 ]

--- a/packages/guru-core/src/guru_core/autostart.py
+++ b/packages/guru-core/src/guru_core/autostart.py
@@ -25,13 +25,8 @@ def _cleanup_stale(guru_dir: Path) -> None:
     (guru_dir / "guru.pid").unlink(missing_ok=True)
 
 
-def ensure_server(guru_root: Path, timeout: float = 5.0) -> None:
-    """Ensure the guru server is running.
-
-    If the server is running (valid PID, socket exists), return immediately.
-    If stale state is detected, clean up and restart.
-    If no server is running, start one.
-    """
+def ensure_server(guru_root: Path, timeout: float = 5.0, log_level: str | None = None) -> None:
+    """Ensure the guru server is running."""
     guru_dir = guru_root / ".guru"
     pid_file = guru_dir / "guru.pid"
     sock_file = guru_dir / "guru.sock"
@@ -41,34 +36,37 @@ def ensure_server(guru_root: Path, timeout: float = 5.0) -> None:
         try:
             pid = int(pid_file.read_text().strip())
             if _is_pid_alive(pid):
-                return  # Server is running
+                return
         except (ValueError, OSError):
             pass
 
-    # Clean up stale state
     _cleanup_stale(guru_dir)
 
-    # Start server, capturing stderr to a log file for diagnostics
     env = os.environ.copy()
     env["GURU_PROJECT_ROOT"] = str(guru_root)
 
+    # Build server command with logging args
+    cmd = ["guru-server", "--log-file", str(guru_dir / "server.log")]
+    log_level_resolved = log_level or os.environ.get("GURU_LOG_LEVEL")
+    if log_level_resolved:
+        cmd.extend(["--log-level", log_level_resolved])
+
+    # Redirect stderr to server.log in append mode as safety net for early crashes
     log_path = guru_dir / "server.log"
-    log_file = open(log_path, "w")  # noqa: SIM115
+    log_file = open(log_path, "a")  # noqa: SIM115
 
     proc = subprocess.Popen(
-        ["guru-server"],
+        cmd,
         stdout=subprocess.DEVNULL,
         stderr=log_file,
         start_new_session=True,
         env=env,
     )
 
-    # Wait for socket to appear, then verify server is healthy via GET /status
     deadline = time.monotonic() + timeout
     last_error: Exception | None = None
 
     while time.monotonic() < deadline:
-        # Detect early process exit before waiting for the full timeout
         if proc.poll() is not None:
             log_file.close()
             log_tail = _read_log_tail(log_path)

--- a/packages/guru-core/src/guru_core/autostart.py
+++ b/packages/guru-core/src/guru_core/autostart.py
@@ -25,7 +25,12 @@ def _cleanup_stale(guru_dir: Path) -> None:
     (guru_dir / "guru.pid").unlink(missing_ok=True)
 
 
-def ensure_server(guru_root: Path, timeout: float = 5.0, log_level: str | None = None) -> None:
+def ensure_server(
+    guru_root: Path,
+    timeout: float = 5.0,
+    log_level: str | None = None,
+    log_file: str | None = None,
+) -> None:
     """Ensure the guru server is running."""
     guru_dir = guru_root / ".guru"
     pid_file = guru_dir / "guru.pid"
@@ -46,7 +51,8 @@ def ensure_server(guru_root: Path, timeout: float = 5.0, log_level: str | None =
     env["GURU_PROJECT_ROOT"] = str(guru_root)
 
     # Build server command with logging args
-    cmd = ["guru-server", "--log-file", str(guru_dir / "server.log")]
+    log_file_resolved = log_file or str(guru_dir / "server.log")
+    cmd = ["guru-server", "--log-file", log_file_resolved]
     log_level_resolved = log_level or os.environ.get("GURU_LOG_LEVEL")
     if log_level_resolved:
         cmd.extend(["--log-level", log_level_resolved])

--- a/packages/guru-core/src/guru_core/client.py
+++ b/packages/guru-core/src/guru_core/client.py
@@ -9,6 +9,10 @@ import httpx
 class GuruClient:
     """Async HTTP client for the guru-server REST API over Unix domain socket."""
 
+    # Server is local (UDS) so connection should be fast, but server-side
+    # processing (e.g. Ollama embeddings during indexing) can take minutes.
+    _timeout = httpx.Timeout(5.0, read=None)
+
     def __init__(self, guru_root: Path):
         self.guru_root = guru_root
         self.socket_path = str(guru_root / ".guru" / "guru.sock")
@@ -17,14 +21,14 @@ class GuruClient:
         return httpx.AsyncHTTPTransport(uds=self.socket_path)
 
     async def _get(self, path: str) -> dict | list:
-        async with httpx.AsyncClient(transport=self._transport()) as client:
+        async with httpx.AsyncClient(transport=self._transport(), timeout=self._timeout) as client:
             resp = await client.get(f"http://localhost{path}")
             if resp.is_error:
                 resp.raise_for_status()
             return resp.json()
 
     async def _post(self, path: str, json: dict) -> dict | list:
-        async with httpx.AsyncClient(transport=self._transport()) as client:
+        async with httpx.AsyncClient(transport=self._transport(), timeout=self._timeout) as client:
             resp = await client.post(f"http://localhost{path}", json=json)
             if resp.is_error:
                 resp.raise_for_status()

--- a/packages/guru-core/src/guru_core/client.py
+++ b/packages/guru-core/src/guru_core/client.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from urllib.parse import quote, urlencode
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 
 class GuruClient:
@@ -22,14 +25,18 @@ class GuruClient:
 
     async def _get(self, path: str) -> dict | list:
         async with httpx.AsyncClient(transport=self._transport(), timeout=self._timeout) as client:
+            logger.debug("GET %s", path)
             resp = await client.get(f"http://localhost{path}")
+            logger.debug("GET %s -> %d", path, resp.status_code)
             if resp.is_error:
                 resp.raise_for_status()
             return resp.json()
 
     async def _post(self, path: str, json: dict) -> dict | list:
         async with httpx.AsyncClient(transport=self._transport(), timeout=self._timeout) as client:
+            logger.debug("POST %s", path)
             resp = await client.post(f"http://localhost{path}", json=json)
+            logger.debug("POST %s -> %d", path, resp.status_code)
             if resp.is_error:
                 resp.raise_for_status()
             return resp.json()

--- a/packages/guru-core/src/guru_core/log.py
+++ b/packages/guru-core/src/guru_core/log.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from logging.handlers import RotatingFileHandler
+
+LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+_GURU_HANDLER_ATTR = "_guru_logging"
+
+
+def setup_logging(
+    level: str | None = None,
+    log_file: str | None = None,
+    max_bytes: int = 10 * 1024 * 1024,
+    backup_count: int = 3,
+) -> None:
+    """Configure logging for all guru packages.
+
+    Args:
+        level: Log level name (DEBUG, INFO, WARNING, ERROR).
+               Falls back to GURU_LOG_LEVEL env var, then INFO.
+        log_file: Optional path for a RotatingFileHandler.
+        max_bytes: Max log file size before rotation (default 10MB).
+        backup_count: Number of rotated files to keep (default 3).
+    """
+    root = logging.getLogger()
+
+    # Remove any handlers we previously added (idempotent)
+    root.handlers = [h for h in root.handlers if not getattr(h, _GURU_HANDLER_ATTR, False)]
+
+    # Resolve level: explicit arg > env var > INFO
+    if level is None:
+        level = os.environ.get("GURU_LOG_LEVEL", "INFO")
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+    formatter = logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT)
+
+    # Always add stderr handler
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(formatter)
+    setattr(stderr_handler, _GURU_HANDLER_ATTR, True)
+    root.addHandler(stderr_handler)
+
+    # Optionally add rotating file handler
+    if log_file:
+        file_handler = RotatingFileHandler(log_file, maxBytes=max_bytes, backupCount=backup_count)
+        file_handler.setFormatter(formatter)
+        setattr(file_handler, _GURU_HANDLER_ATTR, True)
+        root.addHandler(file_handler)

--- a/packages/guru-core/tests/test_client.py
+++ b/packages/guru-core/tests/test_client.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -132,6 +133,23 @@ class TestGuruClient:
         assert timeout is not None, "Must set explicit timeout, not httpx default 5s"
         assert isinstance(timeout, httpx.Timeout)
         assert timeout.read is None or timeout.read > 60.0
+
+    @pytest.mark.asyncio
+    async def test_post_logs_request_at_debug(self, guru_root, monkeypatch, caplog):
+        """_post logs HTTP method, path, and response status at DEBUG level."""
+        fake_response = httpx.Response(200, json={"indexed": 5, "documents": 2})
+
+        async def fake_post(self, url, **kwargs):
+            return fake_response
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+        client = GuruClient(guru_root=guru_root)
+        with caplog.at_level(logging.DEBUG, logger="guru_core.client"):
+            await client.trigger_index()
+
+        assert any("POST /index" in r.message for r in caplog.records)
+        assert any("200" in r.message for r in caplog.records)
 
 
 class TestEnsureServer:

--- a/packages/guru-core/tests/test_client.py
+++ b/packages/guru-core/tests/test_client.py
@@ -332,3 +332,128 @@ class TestEnsureServer:
         assert stderr_target != subprocess.DEVNULL
         assert hasattr(stderr_target, "name")  # it's a file object
         assert "server.log" in stderr_target.name
+
+    def test_passes_log_file_arg_to_server(self, tmp_path, monkeypatch):
+        """ensure_server passes --log-file pointing to .guru/server.log."""
+        guru_dir = tmp_path / ".guru"
+        guru_dir.mkdir()
+        pid_file = guru_dir / "guru.pid"
+        pid_file.write_text("99999")
+
+        monkeypatch.setattr(
+            "os.kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
+        )
+
+        captured_args = {}
+
+        def fake_popen(*args, **kwargs):
+            captured_args["cmd"] = args[0] if args else kwargs.get("args")
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            return mock_proc
+
+        monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+        original_exists = Path.exists
+        call_count = 0
+
+        def fake_exists(self):
+            nonlocal call_count
+            if self.name == "guru.sock":
+                call_count += 1
+                return call_count > 1
+            return original_exists(self)
+
+        monkeypatch.setattr(Path, "exists", fake_exists)
+        monkeypatch.setattr("guru_core.autostart._health_check", lambda sock_path: None)
+
+        ensure_server(tmp_path)
+
+        cmd = captured_args["cmd"]
+        assert "--log-file" in cmd
+        log_file_idx = cmd.index("--log-file")
+        log_file_path = cmd[log_file_idx + 1]
+        assert log_file_path == str(guru_dir / "server.log")
+
+    def test_passes_log_level_from_env(self, tmp_path, monkeypatch):
+        """ensure_server forwards GURU_LOG_LEVEL as --log-level arg."""
+        guru_dir = tmp_path / ".guru"
+        guru_dir.mkdir()
+        pid_file = guru_dir / "guru.pid"
+        pid_file.write_text("99999")
+
+        monkeypatch.setattr(
+            "os.kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
+        )
+        monkeypatch.setenv("GURU_LOG_LEVEL", "DEBUG")
+
+        captured_args = {}
+
+        def fake_popen(*args, **kwargs):
+            captured_args["cmd"] = args[0] if args else kwargs.get("args")
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            return mock_proc
+
+        monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+        original_exists = Path.exists
+        call_count = 0
+
+        def fake_exists(self):
+            nonlocal call_count
+            if self.name == "guru.sock":
+                call_count += 1
+                return call_count > 1
+            return original_exists(self)
+
+        monkeypatch.setattr(Path, "exists", fake_exists)
+        monkeypatch.setattr("guru_core.autostart._health_check", lambda sock_path: None)
+
+        ensure_server(tmp_path)
+
+        cmd = captured_args["cmd"]
+        assert "--log-level" in cmd
+        level_idx = cmd.index("--log-level")
+        assert cmd[level_idx + 1] == "DEBUG"
+
+    def test_stderr_redirected_in_append_mode(self, tmp_path, monkeypatch):
+        """Daemon stderr goes to server.log in append mode (not truncate)."""
+        guru_dir = tmp_path / ".guru"
+        guru_dir.mkdir()
+        pid_file = guru_dir / "guru.pid"
+        pid_file.write_text("99999")
+
+        monkeypatch.setattr(
+            "os.kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
+        )
+
+        captured_kwargs = {}
+
+        def fake_popen(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            return mock_proc
+
+        monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+        original_exists = Path.exists
+        call_count = 0
+
+        def fake_exists(self):
+            nonlocal call_count
+            if self.name == "guru.sock":
+                call_count += 1
+                return call_count > 1
+            return original_exists(self)
+
+        monkeypatch.setattr(Path, "exists", fake_exists)
+        monkeypatch.setattr("guru_core.autostart._health_check", lambda sock_path: None)
+
+        ensure_server(tmp_path)
+
+        stderr_target = captured_kwargs.get("stderr")
+        assert stderr_target is not None
+        assert hasattr(stderr_target, "mode")
+        assert "a" in stderr_target.mode

--- a/packages/guru-core/tests/test_client.py
+++ b/packages/guru-core/tests/test_client.py
@@ -74,6 +74,65 @@ class TestGuruClient:
         assert len(results) == 1
         assert results[0]["file_path"] == "auth.md"
 
+    @pytest.mark.asyncio
+    async def test_post_sets_explicit_read_timeout(self, guru_root, monkeypatch):
+        """_post must set an explicit read timeout, not rely on httpx's 5s default (#14)."""
+        captured_timeouts = []
+
+        class FakeAsyncClient:
+            def __init__(self, **kwargs):
+                captured_timeouts.append(kwargs.get("timeout"))
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def post(self, url, **kwargs):
+                return httpx.Response(200, json={"indexed": 5, "documents": 2})
+
+        monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+        client = GuruClient(guru_root=guru_root)
+        await client.trigger_index()
+
+        assert captured_timeouts, "AsyncClient should have been instantiated"
+        timeout = captured_timeouts[0]
+        assert timeout is not None, "Must set explicit timeout, not httpx default 5s"
+        assert isinstance(timeout, httpx.Timeout)
+        # Read timeout must be None (unlimited) or generous (> 60s)
+        assert timeout.read is None or timeout.read > 60.0
+
+    @pytest.mark.asyncio
+    async def test_get_sets_explicit_read_timeout(self, guru_root, monkeypatch):
+        """_get must set an explicit read timeout, not rely on httpx's 5s default (#14)."""
+        captured_timeouts = []
+
+        class FakeAsyncClient:
+            def __init__(self, **kwargs):
+                captured_timeouts.append(kwargs.get("timeout"))
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def get(self, url, **kwargs):
+                return httpx.Response(200, json={"server_running": True})
+
+        monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+        client = GuruClient(guru_root=guru_root)
+        await client.status()
+
+        assert captured_timeouts, "AsyncClient should have been instantiated"
+        timeout = captured_timeouts[0]
+        assert timeout is not None, "Must set explicit timeout, not httpx default 5s"
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.read is None or timeout.read > 60.0
+
 
 class TestEnsureServer:
     def test_server_already_running(self, tmp_path, monkeypatch):

--- a/packages/guru-core/tests/test_log.py
+++ b/packages/guru-core/tests/test_log.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+
+import pytest
+
+from guru_core.log import _GURU_HANDLER_ATTR, setup_logging
+
+LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+
+def _guru_stream_handlers(root: logging.Logger) -> list[logging.Handler]:
+    """Return only StreamHandlers (not FileHandlers) added by setup_logging."""
+    return [
+        h
+        for h in root.handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+        and getattr(h, _GURU_HANDLER_ATTR, False)
+    ]
+
+
+def _guru_file_handlers(root: logging.Logger) -> list[logging.Handler]:
+    """Return only FileHandlers added by setup_logging."""
+    return [
+        h
+        for h in root.handlers
+        if isinstance(h, logging.FileHandler) and getattr(h, _GURU_HANDLER_ATTR, False)
+    ]
+
+
+class TestSetupLogging:
+    @pytest.fixture(autouse=True)
+    def reset_root_logger(self):
+        """Remove all handlers added during a test."""
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_level = root.level
+        yield
+        root.handlers = original_handlers
+        root.level = original_level
+
+    def test_default_level_is_info(self):
+        setup_logging()
+        root = logging.getLogger()
+        assert root.level == logging.INFO
+
+    def test_level_override(self):
+        setup_logging(level="DEBUG")
+        root = logging.getLogger()
+        assert root.level == logging.DEBUG
+
+    def test_stderr_handler_always_added(self):
+        setup_logging()
+        root = logging.getLogger()
+        assert len(_guru_stream_handlers(root)) == 1
+
+    def test_file_handler_added_when_log_file_provided(self, tmp_path):
+        log_file = str(tmp_path / "test.log")
+        setup_logging(log_file=log_file)
+        root = logging.getLogger()
+        file_handlers = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+        assert len(file_handlers) == 1
+        assert file_handlers[0].maxBytes == 10 * 1024 * 1024
+        assert file_handlers[0].backupCount == 3
+
+    def test_no_file_handler_when_log_file_not_provided(self):
+        setup_logging()
+        root = logging.getLogger()
+        assert len(_guru_file_handlers(root)) == 0
+
+    def test_log_format(self):
+        setup_logging()
+        root = logging.getLogger()
+        guru_handlers = [h for h in root.handlers if getattr(h, _GURU_HANDLER_ATTR, False)]
+        assert guru_handlers[-1].formatter._fmt == LOG_FORMAT
+
+    def test_writes_to_log_file(self, tmp_path):
+        log_file = tmp_path / "test.log"
+        setup_logging(level="INFO", log_file=str(log_file))
+        logger = logging.getLogger("test.writes")
+        logger.info("hello from test")
+        # Flush handlers
+        for h in logging.getLogger().handlers:
+            h.flush()
+        content = log_file.read_text()
+        assert "hello from test" in content
+
+    def test_env_var_fallback(self, monkeypatch):
+        monkeypatch.setenv("GURU_LOG_LEVEL", "WARNING")
+        setup_logging()
+        root = logging.getLogger()
+        assert root.level == logging.WARNING
+
+    def test_explicit_level_overrides_env_var(self, monkeypatch):
+        monkeypatch.setenv("GURU_LOG_LEVEL", "WARNING")
+        setup_logging(level="DEBUG")
+        root = logging.getLogger()
+        assert root.level == logging.DEBUG
+
+    def test_idempotent_no_duplicate_handlers(self):
+        setup_logging()
+        setup_logging()
+        root = logging.getLogger()
+        assert len(_guru_stream_handlers(root)) == 1

--- a/packages/guru-server/src/guru_server/api/index.py
+++ b/packages/guru-server/src/guru_server/api/index.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -5,6 +7,8 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from guru_server.api.models import IndexOut
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -18,6 +22,7 @@ class IndexBody(BaseModel):
 
 @router.post("/index", response_model=IndexOut)
 async def trigger_index(body: IndexBody, request: Request):
+    logger.info("Indexing requested (path=%s)", body.path or "project root")
     store = request.app.state.store
     embedder = request.app.state.embedder
     config = request.app.state.config
@@ -70,8 +75,22 @@ async def trigger_index(body: IndexBody, request: Request):
         store.delete_files(indexed_paths)
 
         texts = [chunk.content for chunk in all_chunks]
-        vectors = await embedder.embed_batch(texts)
+        t0 = time.monotonic()
+        try:
+            vectors = await embedder.embed_batch(texts)
+        except Exception:
+            logger.exception("Embedding failed during indexing")
+            raise
         store.add_chunks(all_chunks, vectors)
+        elapsed = time.monotonic() - t0
+        logger.info(
+            "Indexing complete: %d chunks from %d documents in %.1fs",
+            len(all_chunks),
+            len({c.file_path for c in all_chunks}),
+            elapsed,
+        )
+    else:
+        logger.info("Indexing complete: no documents matched")
 
     request.app.state.last_indexed = datetime.now(UTC)
 

--- a/packages/guru-server/src/guru_server/embedding.py
+++ b/packages/guru-server/src/guru_server/embedding.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import logging
+import time
+
 import httpx
+
+logger = logging.getLogger(__name__)
 
 
 class EmbeddingError(RuntimeError):
@@ -13,6 +18,8 @@ class OllamaEmbedder:
         self.base_url = base_url
 
     async def embed(self, text: str) -> list[float]:
+        logger.debug("Embedding text (length=%d)", len(text))
+        t0 = time.monotonic()
         async with httpx.AsyncClient() as client:
             response = await client.post(
                 f"{self.base_url}/api/embeddings",
@@ -20,24 +27,38 @@ class OllamaEmbedder:
                 timeout=30.0,
             )
         if response.status_code != 200:
+            logger.error("Ollama embedding failed (%d): %s", response.status_code, response.text)
             raise EmbeddingError(
                 f"Ollama embedding failed ({response.status_code}): {response.text}"
             )
+        logger.debug("Embedding complete in %.2fs", time.monotonic() - t0)
         return response.json()["embedding"]
 
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
         """Embed multiple texts reusing a single HTTP client for efficiency."""
+        logger.debug("Embedding batch of %d texts", len(texts))
+        t0 = time.monotonic()
         async with httpx.AsyncClient() as client:
             results = []
-            for text in texts:
+            for i, text in enumerate(texts):
                 response = await client.post(
                     f"{self.base_url}/api/embeddings",
                     json={"model": self.model, "prompt": text},
                     timeout=30.0,
                 )
                 if response.status_code != 200:
+                    logger.error(
+                        "Ollama embedding failed for text %d/%d (%d): %s",
+                        i + 1,
+                        len(texts),
+                        response.status_code,
+                        response.text,
+                    )
                     raise EmbeddingError(
                         f"Ollama embedding failed ({response.status_code}): {response.text}"
                     )
                 results.append(response.json()["embedding"])
-            return results
+        logger.debug(
+            "Batch embedding complete: %d texts in %.2fs", len(texts), time.monotonic() - t0
+        )
+        return results

--- a/packages/guru-server/src/guru_server/main.py
+++ b/packages/guru-server/src/guru_server/main.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import argparse
+import logging
 import os
 import sys
 from pathlib import Path
 
 import uvicorn
 
+from guru_core.log import DATE_FORMAT, LOG_FORMAT, setup_logging
 from guru_server.app import create_app
 from guru_server.config import resolve_config
 from guru_server.embedding import OllamaEmbedder
@@ -17,22 +20,77 @@ from guru_server.startup import (
 )
 from guru_server.storage import VectorStore
 
+logger = logging.getLogger(__name__)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Guru knowledge-base server")
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default=None,
+        help="Log level (default: INFO, overrides GURU_LOG_LEVEL env var)",
+    )
+    parser.add_argument(
+        "--log-file",
+        default=None,
+        help="Path to log file (enables rotating file handler)",
+    )
+    return parser.parse_args(argv)
+
+
+def _uvicorn_log_config(formatter_fmt: str, date_fmt: str) -> dict:
+    """Build a uvicorn log_config that reuses our log format."""
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {"fmt": formatter_fmt, "datefmt": date_fmt},
+            "access": {"fmt": formatter_fmt, "datefmt": date_fmt},
+        },
+        "handlers": {
+            "default": {
+                "class": "logging.StreamHandler",
+                "formatter": "default",
+                "stream": "ext://sys.stderr",
+            },
+            "access": {
+                "class": "logging.StreamHandler",
+                "formatter": "access",
+                "stream": "ext://sys.stderr",
+            },
+        },
+        "loggers": {
+            "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
+            "uvicorn.error": {"level": "INFO"},
+            "uvicorn.access": {
+                "handlers": ["access"],
+                "level": "INFO",
+                "propagate": False,
+            },
+        },
+    }
+
 
 def main():
+    args = _parse_args()
+    setup_logging(level=args.log_level, log_file=args.log_file)
+
     project_root = os.environ.get("GURU_PROJECT_ROOT", os.getcwd())
     guru_dir = Path(project_root) / ".guru"
 
     if not guru_dir.is_dir():
-        print(f"Error: {guru_dir} does not exist. Run `guru init` first.", file=sys.stderr)
+        logger.error("%s does not exist. Run `guru init` first.", guru_dir)
         sys.exit(1)
 
-    # Preflight checks + startup — ensure ollama_proc is always cleaned up
+    logger.info("Starting guru-server (project_root=%s)", project_root)
+
+    # Preflight checks + startup
     check_ollama_installed()
     ollama_proc = start_ollama_serve()
     try:
         check_model_available("nomic-embed-text")
 
-        # Initialize components
         config = resolve_config(project_root=Path(project_root))
         store = VectorStore(db_path=str(guru_dir / "db"))
         embedder = OllamaEmbedder()
@@ -47,14 +105,18 @@ def main():
         socket_path = str(guru_dir / "guru.sock")
         pid_path = guru_dir / "guru.pid"
 
-        # Write PID file
         pid_path.write_text(str(os.getpid()))
+        logger.info("Listening on %s (PID %d)", socket_path, os.getpid())
 
         try:
-            uvicorn.run(app, uds=socket_path, log_level="info")
+            uvicorn.run(
+                app,
+                uds=socket_path,
+                log_config=_uvicorn_log_config(LOG_FORMAT, DATE_FORMAT),
+            )
         finally:
-            # Cleanup
             pid_path.unlink(missing_ok=True)
             Path(socket_path).unlink(missing_ok=True)
+            logger.info("Server shut down")
     finally:
         stop_ollama_serve(ollama_proc)

--- a/packages/guru-server/src/guru_server/main.py
+++ b/packages/guru-server/src/guru_server/main.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import uvicorn
 
-from guru_core.log import DATE_FORMAT, LOG_FORMAT, setup_logging
+from guru_core.log import setup_logging
 from guru_server.app import create_app
 from guru_server.config import resolve_config
 from guru_server.embedding import OllamaEmbedder
@@ -39,41 +39,26 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _uvicorn_log_config(formatter_fmt: str, date_fmt: str) -> dict:
-    """Build a uvicorn log_config that reuses our log format."""
+def _uvicorn_log_config() -> dict:
+    """Build a uvicorn log_config that propagates to the root logger.
+
+    By setting propagate=True and removing custom handlers, uvicorn logs
+    flow through the root logger's handlers (stderr + optional file),
+    giving a unified log format and destination.
+    """
     return {
         "version": 1,
         "disable_existing_loggers": False,
-        "formatters": {
-            "default": {"fmt": formatter_fmt, "datefmt": date_fmt},
-            "access": {"fmt": formatter_fmt, "datefmt": date_fmt},
-        },
-        "handlers": {
-            "default": {
-                "class": "logging.StreamHandler",
-                "formatter": "default",
-                "stream": "ext://sys.stderr",
-            },
-            "access": {
-                "class": "logging.StreamHandler",
-                "formatter": "access",
-                "stream": "ext://sys.stderr",
-            },
-        },
         "loggers": {
-            "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
-            "uvicorn.error": {"level": "INFO"},
-            "uvicorn.access": {
-                "handlers": ["access"],
-                "level": "INFO",
-                "propagate": False,
-            },
+            "uvicorn": {"level": "INFO", "propagate": True},
+            "uvicorn.error": {"level": "INFO", "propagate": True},
+            "uvicorn.access": {"level": "INFO", "propagate": True},
         },
     }
 
 
-def main():
-    args = _parse_args()
+def main(argv: list[str] | None = None):
+    args = _parse_args(argv)
     setup_logging(level=args.log_level, log_file=args.log_file)
 
     project_root = os.environ.get("GURU_PROJECT_ROOT", os.getcwd())
@@ -112,7 +97,7 @@ def main():
             uvicorn.run(
                 app,
                 uds=socket_path,
-                log_config=_uvicorn_log_config(LOG_FORMAT, DATE_FORMAT),
+                log_config=_uvicorn_log_config(),
             )
         finally:
             pid_path.unlink(missing_ok=True)

--- a/packages/guru-server/src/guru_server/startup.py
+++ b/packages/guru-server/src/guru_server/startup.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import logging
 import shutil
 import subprocess
+
+logger = logging.getLogger(__name__)
 
 
 class OllamaNotFoundError(RuntimeError):
@@ -19,6 +22,7 @@ def check_ollama_installed() -> None:
             "Install it with: brew install ollama\n"
             "Or visit: https://ollama.com"
         )
+    logger.info("Ollama found on PATH")
 
 
 def check_model_available(model: str = "nomic-embed-text") -> None:
@@ -38,14 +42,17 @@ def check_model_available(model: str = "nomic-embed-text") -> None:
         raise ModelNotFoundError(
             f"Model '{model}' is not available.\nPull it with: ollama pull {model}"
         )
+    logger.info("Model '%s' is available", model)
 
 
 def start_ollama_serve() -> subprocess.Popen | None:
     try:
         subprocess.run(["ollama", "list"], capture_output=True, text=True, check=True, timeout=5)
+        logger.info("Ollama is already running")
         return None
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         pass
+    logger.info("Starting ollama serve")
     return subprocess.Popen(
         ["ollama", "serve"],
         stdout=subprocess.DEVNULL,

--- a/packages/guru-server/src/guru_server/storage.py
+++ b/packages/guru-server/src/guru_server/storage.py
@@ -25,12 +25,12 @@ class VectorStore:
             try:
                 self._table = self.db.open_table(TABLE_NAME)
             except FileNotFoundError:
-                logger.warning("Table '%s' not found (no data indexed yet)", TABLE_NAME)
+                logger.debug("Table '%s' not found (no data indexed yet)", TABLE_NAME)
                 return None
             except Exception as exc:
                 msg = str(exc).lower()
                 if any(phrase in msg for phrase in _TABLE_NOT_FOUND_PHRASES):
-                    logger.warning("Table '%s' not found: %s", TABLE_NAME, exc)
+                    logger.debug("Table '%s' not found: %s", TABLE_NAME, exc)
                     return None
                 raise
         return self._table

--- a/packages/guru-server/src/guru_server/storage.py
+++ b/packages/guru-server/src/guru_server/storage.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import lancedb
 
 from guru_server.ingestion.base import Chunk
+
+logger = logging.getLogger(__name__)
 
 VECTOR_DIM = 768
 TABLE_NAME = "chunks"
@@ -22,10 +25,12 @@ class VectorStore:
             try:
                 self._table = self.db.open_table(TABLE_NAME)
             except FileNotFoundError:
+                logger.warning("Table '%s' not found (no data indexed yet)", TABLE_NAME)
                 return None
             except Exception as exc:
                 msg = str(exc).lower()
                 if any(phrase in msg for phrase in _TABLE_NOT_FOUND_PHRASES):
+                    logger.warning("Table '%s' not found: %s", TABLE_NAME, exc)
                     return None
                 raise
         return self._table
@@ -187,6 +192,7 @@ def _parse_json_list(value: str) -> list:
         result = json.loads(value)
         return result if isinstance(result, list) else []
     except (json.JSONDecodeError, TypeError):
+        logger.warning("Failed to parse JSON list: %.100s", value)
         return []
 
 
@@ -196,6 +202,7 @@ def _parse_json_dict(value: str) -> dict:
         result = json.loads(value)
         return result if isinstance(result, dict) else {}
     except (json.JSONDecodeError, TypeError):
+        logger.warning("Failed to parse JSON dict: %.100s", value)
         return {}
 
 

--- a/packages/guru-server/tests/test_main.py
+++ b/packages/guru-server/tests/test_main.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+class TestMainArgParsing:
+    @pytest.fixture(autouse=True)
+    def reset_root_logger(self):
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_level = root.level
+        yield
+        root.handlers = original_handlers
+        root.level = original_level
+
+    def test_parse_log_level_flag(self):
+        from guru_server.main import _parse_args
+
+        args = _parse_args(["--log-level", "DEBUG"])
+        assert args.log_level == "DEBUG"
+
+    def test_parse_log_file_flag(self):
+        from guru_server.main import _parse_args
+
+        args = _parse_args(["--log-file", "/tmp/test.log"])
+        assert args.log_file == "/tmp/test.log"
+
+    def test_default_log_level_is_none(self):
+        from guru_server.main import _parse_args
+
+        args = _parse_args([])
+        assert args.log_level is None
+
+    def test_default_log_file_is_none(self):
+        from guru_server.main import _parse_args
+
+        args = _parse_args([])
+        assert args.log_file is None


### PR DESCRIPTION
## Summary
- **Client timeout fix (#14):** `GuruClient` relied on httpx's default 5s timeout. Set `_timeout = httpx.Timeout(5.0, read=None)` — connection timeout stays at 5s, read timeout is unlimited since the server is local (UDS)
- **Server logging infrastructure:** Proper Python `logging` throughout the codebase — `setup_logging()` in guru-core, `RotatingFileHandler` (10MB, 3 backups), configurable log levels via `--log-level` flag and `GURU_LOG_LEVEL` env var
- **Foreground mode:** `guru server start --foreground` for interactive debugging with logs in the terminal
- **Log file support:** `guru server start --log-file PATH` to tee logs to a file; daemon mode defaults to `.guru/server.log` (append, not truncate)
- **Structured logging in server modules:** INFO/DEBUG/WARNING/ERROR calls in index, embedding, storage, and startup modules — errors are now always visible

Closes #14

## Test plan
- [x] 134 unit/integration tests pass (22 new tests added)
- [x] 24 e2e scenarios pass (3 features, 184 steps)
- [x] Linter clean (`ruff check` + `ruff format`)
- [x] TDD: client timeout tests written and verified RED before GREEN
- [x] Code review: fixed uvicorn log propagation, `--log-file` forwarding in daemon mode, `sys.argv` mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)