### PR TITLE
fix: Sanitize YAML frontmatter dates to prevent JSON serialization error

### DIFF
--- a/packages/guru-server/src/guru_server/ingestion/markdown.py
+++ b/packages/guru-server/src/guru_server/ingestion/markdown.py
@@ -28,6 +28,23 @@ def _detect_content_type(content: str) -> str:
     return "text"
 
 
+def _sanitize_frontmatter(obj):
+    """Recursively convert non-JSON-serializable values to strings.
+
+    YAML parsing produces datetime.date/datetime objects that json.dumps
+    cannot handle. Convert them to ISO-format strings.
+    """
+    import datetime
+
+    if isinstance(obj, dict):
+        return {k: _sanitize_frontmatter(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_frontmatter(v) for v in obj]
+    if isinstance(obj, datetime.datetime | datetime.date):
+        return obj.isoformat()
+    return obj
+
+
 class MarkdownParser(DocumentParser):
     def supports(self, file_path: Path) -> bool:
         return file_path.suffix.lower() in (".md", ".markdown")
@@ -35,7 +52,7 @@ class MarkdownParser(DocumentParser):
     def parse(self, file_path: Path, rule: Rule) -> list[Chunk]:
         raw = file_path.read_text(encoding="utf-8")
         post = frontmatter.loads(raw)
-        fm = dict(post.metadata)
+        fm = _sanitize_frontmatter(dict(post.metadata))
         doc = Document(text=post.content, metadata={"source": str(file_path)})
         parser = LlamaMarkdownParser()
         nodes = parser.get_nodes_from_documents([doc])

--- a/packages/guru-server/tests/test_ingestion.py
+++ b/packages/guru-server/tests/test_ingestion.py
@@ -373,3 +373,41 @@ def test_max_tokens_stored_as_metadata(
     # max_tokens is Phase 2 work; just verify the parse call doesn't blow up
     # and that chunks still have content
     assert all(c.content for c in chunks)
+
+
+# --- Frontmatter with non-JSON-serializable YAML types (issue #17) ---
+
+SAMPLE_MD_WITH_DATE = """\
+---
+title: Change Request
+date: 2025-01-15
+updated: 2025-06-20 14:30:00
+---
+
+# Change Request
+
+Some content here.
+"""
+
+
+def test_frontmatter_with_dates_is_json_serializable(
+    parser: MarkdownParser, tmp_path: Path, rule: Rule
+):
+    """Frontmatter containing YAML dates must be JSON-serializable (issue #17).
+
+    python-frontmatter parses YAML dates into datetime.date/datetime objects,
+    which json.dumps cannot serialize. The parser must sanitize these to strings.
+    """
+    import json
+
+    p = tmp_path / "cr_001.md"
+    p.write_text(SAMPLE_MD_WITH_DATE, encoding="utf-8")
+    chunks = parser.parse(p, rule)
+    assert chunks, "Expected at least one chunk"
+    for chunk in chunks:
+        # This must not raise TypeError
+        serialized = json.dumps(chunk.frontmatter)
+        # Verify round-trip preserves values as strings
+        restored = json.loads(serialized)
+        assert restored["title"] == "Change Request"
+        assert restored["date"] == "2025-01-15"


### PR DESCRIPTION
## Summary

- Fixes indexing 500 error caused by `python-frontmatter` parsing YAML dates into `datetime.date`/`datetime` objects that `json.dumps()` cannot serialize
- Adds `_sanitize_frontmatter()` in `MarkdownParser` to recursively convert non-JSON-serializable values to ISO-format strings before storing in `Chunk` objects
- Adds regression test with date and datetime frontmatter values

Closes #17

## Test plan

- [x] New test `test_frontmatter_with_dates_is_json_serializable` verifies frontmatter with YAML dates is JSON-serializable after parsing
- [x] Full test suite passes (118 tests)
- [x] Ruff lint passes
- [x] Manual test: indexed 3 documents with `date`, `updated`, `deadline`, `created`, `revised` YAML date fields — all serialized as ISO strings, 6 chunks indexed successfully with status 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)