### PR TITLE
test: fix federation UDS path length on macOS

### DIFF
--- a/tests/e2e/features/environment.py
+++ b/tests/e2e/features/environment.py
@@ -614,8 +614,10 @@ def before_feature(context, feature):
     if "federation" in feature.tags:
         # Federation tests manage their own servers via step definitions.
         # Create a shared federation directory and a shared embedder.
-        context.fed_dir = Path(tempfile.mkdtemp(prefix="guru-fed-"))
-        context.fed_base_dir = Path(tempfile.mkdtemp(prefix="guru-fed-projects-"))
+        # Short paths under /tmp — macOS caps AF_UNIX paths at 104 bytes, and
+        # the default TMPDIR (/var/folders/…) alone eats ~53 of those.
+        context.fed_dir = Path(tempfile.mkdtemp(prefix="g_fed_", dir="/tmp"))
+        context.fed_base_dir = Path(tempfile.mkdtemp(prefix="g_fedp_", dir="/tmp"))
         context.embedder = _make_fake_embedder()
         context.servers = {}
         context.registries = {}


### PR DESCRIPTION
## Summary
- `make test-e2e` errored on `federation_discovery.feature:8` (\"Server uses directory name when no name in config\") with `PermissionError: [Errno 1] Operation not permitted` on `sock.bind()`.
- Root cause: macOS caps AF_UNIX socket paths at 104 bytes. The federation test fixture used the default TMPDIR (`/var/folders/…/T/`, ~53 bytes), which made the `my-cool-project` socket path overflow at 111 bytes. `alpha` (101 bytes) squeaked under the limit, which is why only that one scenario failed.
- Fix: create `fed_dir` / `fed_base_dir` under `/tmp` with short prefixes, matching the convention used by `_create_standard_project` and documented in AGENTS.md.

## Test plan
- [x] `unset TMPDIR && uv run behave tests/e2e/features/federation_discovery.feature` → 3/3 pass
- [x] `unset TMPDIR && uv run behave tests/e2e/features/ --tags=federation` → 8/8 pass

Generated with Claude Code