### PR TITLE
feat: m0002 schema + ingest routes + Document nodes (PR-2/9)

### DIFF
--- a/packages/guru-core/src/guru_core/__init__.py
+++ b/packages/guru-core/src/guru_core/__init__.py
@@ -10,13 +10,18 @@ from guru_core.discovery import GuruNotFoundError, find_guru_root
 from guru_core.graph_client import GraphClient
 from guru_core.graph_errors import GraphUnavailable
 from guru_core.graph_types import (
+    AnnotationKind,
+    ArtifactLinkKind,
     CypherQuery,
+    GraphEdgePayload,
+    GraphNodePayload,
     Health,
     KbLink,
     KbLinkCreate,
     KbNode,
     KbUpsert,
     LinkKind,
+    ParseResultPayload,
     QueryResult,
     VersionInfo,
 )
@@ -40,12 +45,16 @@ from guru_core.types import (
 
 __all__ = [
     "DEFAULT_RULES",
+    "AnnotationKind",
+    "ArtifactLinkKind",
     "ChunkingConfig",
     "CypherQuery",
     "DocumentInfo",
     "DocumentListItem",
     "DocumentOut",
     "GraphClient",
+    "GraphEdgePayload",
+    "GraphNodePayload",
     "GraphUnavailable",
     "GuruClient",
     "GuruNotFoundError",
@@ -57,6 +66,7 @@ __all__ = [
     "KbUpsert",
     "LinkKind",
     "MatchConfig",
+    "ParseResultPayload",
     "QueryResult",
     "Rule",
     "SearchRequest",

--- a/packages/guru-core/src/guru_core/graph_client.py
+++ b/packages/guru-core/src/guru_core/graph_client.py
@@ -219,7 +219,7 @@ class GraphClient:
         """
         resp = await self._request(
             "POST",
-            f"/ingest/parse-result?kb_name={quote(kb_name)}",
+            f"/ingest/parse-result?kb_name={quote(kb_name, safe='')}",
             json=payload.model_dump(mode="json"),
         )
         if resp.status_code != 204:
@@ -235,7 +235,7 @@ class GraphClient:
         """
         resp = await self._request(
             "DELETE",
-            f"/ingest/documents/{quote(doc_id, safe='')}?kb_name={quote(kb_name)}",
+            f"/ingest/documents/{quote(doc_id, safe='')}?kb_name={quote(kb_name, safe='')}",
         )
         if resp.status_code != 204:
             raise GraphUnavailable(

--- a/packages/guru-core/src/guru_core/graph_client.py
+++ b/packages/guru-core/src/guru_core/graph_client.py
@@ -27,6 +27,7 @@ from .graph_types import (
     KbNode,
     KbUpsert,
     LinkKind,
+    ParseResultPayload,
     QueryResult,
     VersionInfo,
 )
@@ -208,6 +209,38 @@ class GraphClient:
             f"/kbs/{quote(name, safe='')}/links?direction={direction}",
         )
         return [KbLink.model_validate(r) for r in resp.json()]
+
+    async def submit_parse_result(self, *, kb_name: str, payload: ParseResultPayload) -> None:
+        """Submit a ParseResultPayload to the graph daemon's ingest endpoint.
+
+        Raises :class:`GraphUnavailable` on any transport, protocol, or
+        daemon-side error. A successful submission returns nothing; the graph
+        is reconciled in-place.
+        """
+        resp = await self._request(
+            "POST",
+            f"/ingest/parse-result?kb_name={quote(kb_name)}",
+            json=payload.model_dump(mode="json"),
+        )
+        if resp.status_code != 204:
+            raise GraphUnavailable(
+                f"unexpected status from /ingest/parse-result: {resp.status_code}"
+            )
+
+    async def delete_document_in_graph(self, *, kb_name: str, doc_id: str) -> None:
+        """Remove a Document and its CONTAINS subtree from the graph.
+
+        Raises :class:`GraphUnavailable` on any error. Safe to call for a
+        document that doesn't exist in the graph (204 is returned either way).
+        """
+        resp = await self._request(
+            "DELETE",
+            f"/ingest/documents/{quote(doc_id, safe='')}?kb_name={quote(kb_name)}",
+        )
+        if resp.status_code != 204:
+            raise GraphUnavailable(
+                f"unexpected status from /ingest/documents/{doc_id}: {resp.status_code}"
+            )
 
     async def query(
         self,

--- a/packages/guru-core/src/guru_core/graph_client.py
+++ b/packages/guru-core/src/guru_core/graph_client.py
@@ -33,7 +33,7 @@ from .graph_types import (
 
 logger = logging.getLogger(__name__)
 
-PROTOCOL_VERSION = "1.0.0"
+PROTOCOL_VERSION = "1.1.0"
 PROTOCOL_HEADER = "X-Guru-Graph-Protocol"
 
 

--- a/packages/guru-core/src/guru_core/graph_types.py
+++ b/packages/guru-core/src/guru_core/graph_types.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class LinkKind(StrEnum):
@@ -124,3 +124,83 @@ class VersionInfo(BaseModel):
     backend: str
     backend_version: str
     schema_version: int
+
+
+# ---------------------------------------------------------------------------
+# Artifact-graph types (intra-KB RELATES-edge vocabulary and wire schema)
+# ---------------------------------------------------------------------------
+
+
+class ArtifactLinkKind(StrEnum):
+    """Closed vocabulary for intra-KB RELATES-edge kinds.
+
+    These describe relationships between artifacts *within* a single knowledge
+    base (e.g. file imports another file). They are distinct from `LinkKind`
+    which describes KB-to-KB relationships.
+    """
+
+    IMPORTS = "imports"
+    INHERITS_FROM = "inherits_from"
+    IMPLEMENTS = "implements"
+    CALLS = "calls"
+    REFERENCES = "references"
+    DOCUMENTS = "documents"
+
+
+class AnnotationKind(StrEnum):
+    """Closed vocabulary for human/AI annotations attached to graph nodes."""
+
+    SUMMARY = "summary"
+    GOTCHA = "gotcha"
+    CAVEAT = "caveat"
+    NOTE = "note"
+
+
+class GraphNodePayload(BaseModel):
+    """A single node in the artifact graph, as sent over the wire."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    node_id: str
+    label: str
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class GraphEdgePayload(BaseModel):
+    """A directed edge in the artifact graph, as sent over the wire.
+
+    Invariant: a RELATES edge must carry a `kind`; a CONTAINS edge must not.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    from_id: str
+    to_id: str
+    rel_type: Literal["CONTAINS", "RELATES"]
+    kind: str | None = None
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("kind")
+    @classmethod
+    def _kind_consistent(cls, kind: str | None, info: Any) -> str | None:
+        rel_type = info.data.get("rel_type")
+        if rel_type == "RELATES" and kind is None:
+            raise ValueError("kind must not be None when rel_type is 'RELATES'")
+        if rel_type == "CONTAINS" and kind is not None:
+            raise ValueError("kind must be None when rel_type is 'CONTAINS'")
+        return kind
+
+
+class ParseResultPayload(BaseModel):
+    """Wire schema for POST /ingest/parse-result.
+
+    The server's indexer converts its internal `ParseResult` to this model
+    before POSTing to the graph daemon.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    chunks_count: int
+    document: GraphNodePayload
+    nodes: list[GraphNodePayload] = Field(default_factory=list)
+    edges: list[GraphEdgePayload] = Field(default_factory=list)

--- a/packages/guru-core/tests/test_graph_client_protocol_mismatch.py
+++ b/packages/guru-core/tests/test_graph_client_protocol_mismatch.py
@@ -87,4 +87,4 @@ def test_protocol_version_module_constant_is_patchable():
     assert hasattr(gc_module, "PROTOCOL_VERSION")
     with patch("guru_core.graph_client.PROTOCOL_VERSION", "99.0.0"):
         assert gc_module.PROTOCOL_VERSION == "99.0.0"
-    assert gc_module.PROTOCOL_VERSION == "1.0.0"
+    assert gc_module.PROTOCOL_VERSION == "1.1.0"

--- a/packages/guru-core/tests/unit/test_artifact_graph_types.py
+++ b/packages/guru-core/tests/unit/test_artifact_graph_types.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from guru_core.graph_types import (
+    AnnotationKind,
+    ArtifactLinkKind,
+    GraphEdgePayload,
+    GraphNodePayload,
+    ParseResultPayload,
+)
+
+
+def test_artifact_link_kind_values():
+    assert ArtifactLinkKind.IMPORTS == "imports"
+    assert ArtifactLinkKind.INHERITS_FROM == "inherits_from"
+    assert ArtifactLinkKind.IMPLEMENTS == "implements"
+    assert ArtifactLinkKind.CALLS == "calls"
+    assert ArtifactLinkKind.REFERENCES == "references"
+    assert ArtifactLinkKind.DOCUMENTS == "documents"
+
+
+def test_annotation_kind_values():
+    assert set(AnnotationKind) == {
+        AnnotationKind.SUMMARY,
+        AnnotationKind.GOTCHA,
+        AnnotationKind.CAVEAT,
+        AnnotationKind.NOTE,
+    }
+
+
+def test_graph_node_payload_roundtrip():
+    n = GraphNodePayload(node_id="kb::x", label="Document", properties={"a": 1})
+    j = n.model_dump_json()
+    assert GraphNodePayload.model_validate_json(j) == n
+
+
+def test_parse_result_payload_contains_document():
+    pr = ParseResultPayload(
+        chunks_count=3,
+        document=GraphNodePayload(node_id="kb::x", label="Document", properties={}),
+        nodes=[],
+        edges=[],
+    )
+    assert pr.document.label == "Document"
+
+
+def test_graph_edge_relates_requires_kind():
+    with pytest.raises(ValueError):
+        GraphEdgePayload(from_id="a", to_id="b", rel_type="RELATES", kind=None)
+
+
+def test_graph_edge_contains_forbids_kind():
+    with pytest.raises(ValueError):
+        GraphEdgePayload(from_id="a", to_id="b", rel_type="CONTAINS", kind="imports")

--- a/packages/guru-core/tests/unit/test_graph_client_ingest.py
+++ b/packages/guru-core/tests/unit/test_graph_client_ingest.py
@@ -1,0 +1,93 @@
+"""Unit tests for GraphClient.submit_parse_result + delete_document_in_graph."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from guru_core.graph_client import GraphClient
+from guru_core.graph_errors import GraphUnavailable
+from guru_core.graph_types import GraphNodePayload, ParseResultPayload
+
+
+def _client() -> GraphClient:
+    return GraphClient(socket_path="/tmp/x.sock", auto_start=False)
+
+
+def _payload() -> ParseResultPayload:
+    return ParseResultPayload(
+        chunks_count=0,
+        document=GraphNodePayload(node_id="kb::x", label="Document", properties={}),
+        nodes=[],
+        edges=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_parse_result_posts_encoded_query_string():
+    client = _client()
+    fake_response = AsyncMock()
+    fake_response.status_code = 204
+    with patch.object(client, "_request", return_value=fake_response) as r:
+        await client.submit_parse_result(kb_name="my kb", payload=_payload())
+
+    assert r.called
+    args, kwargs = r.call_args.args, r.call_args.kwargs
+    assert args[0] == "POST"
+    # kb_name should be URL-encoded (space → %20)
+    assert args[1] == "/ingest/parse-result?kb_name=my%20kb"
+    assert "json" in kwargs
+    assert kwargs["json"]["document"]["node_id"] == "kb::x"
+
+
+@pytest.mark.asyncio
+async def test_submit_parse_result_raises_on_non_204():
+    client = _client()
+    fake_response = AsyncMock()
+    fake_response.status_code = 200  # unexpected "success" — still an error
+    with (
+        patch.object(client, "_request", return_value=fake_response),
+        pytest.raises(GraphUnavailable),
+    ):
+        await client.submit_parse_result(kb_name="kb", payload=_payload())
+
+
+@pytest.mark.asyncio
+async def test_delete_document_issues_percent_encoded_path():
+    client = _client()
+    fake_response = AsyncMock()
+    fake_response.status_code = 204
+    with patch.object(client, "_request", return_value=fake_response) as r:
+        await client.delete_document_in_graph(kb_name="kb", doc_id="kb::docs/guide.md")
+
+    args = r.call_args.args
+    assert args[0] == "DELETE"
+    # Every special character in doc_id must be percent-encoded (safe='')
+    assert args[1] == "/ingest/documents/kb%3A%3Adocs%2Fguide.md?kb_name=kb"
+
+
+@pytest.mark.asyncio
+async def test_delete_document_raises_on_non_204():
+    client = _client()
+    fake_response = AsyncMock()
+    fake_response.status_code = 404  # (our server doesn't return 404 here, but guard anyway)
+    with (
+        patch.object(client, "_request", return_value=fake_response),
+        pytest.raises(GraphUnavailable),
+    ):
+        await client.delete_document_in_graph(kb_name="kb", doc_id="x")
+
+
+@pytest.mark.asyncio
+async def test_submit_parse_result_propagates_graph_unavailable_from_request():
+    client = _client()
+
+    async def _raise(*_a, **_kw):
+        raise GraphUnavailable("simulated transport error")
+
+    with (
+        patch.object(client, "_request", side_effect=_raise),
+        pytest.raises(GraphUnavailable, match="simulated"),
+    ):
+        await client.submit_parse_result(kb_name="kb", payload=_payload())

--- a/packages/guru-graph/src/guru_graph/app.py
+++ b/packages/guru-graph/src/guru_graph/app.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from .backend.base import GraphBackend
-from .routes import admin, kbs, query
+from .routes import admin, ingest, kbs, query
 from .versioning import (
     PROTOCOL_HEADER,
     PROTOCOL_VERSION,
@@ -50,4 +50,5 @@ def create_app(*, backend: GraphBackend) -> FastAPI:
     app.include_router(admin.router)
     app.include_router(kbs.router)
     app.include_router(query.router)
+    app.include_router(ingest.router)
     return app

--- a/packages/guru-graph/src/guru_graph/backend/base.py
+++ b/packages/guru-graph/src/guru_graph/backend/base.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, ClassVar, Protocol, runtime_checkable
+from typing import Any, ClassVar, Literal, Protocol, runtime_checkable
 
 
 @dataclass(frozen=True)
@@ -84,6 +84,101 @@ class KbOpsBackend(GraphBackend, Protocol):
     def link(self, *, from_kb: str, to_kb: str, kind: str, metadata_json: str) -> None: ...
     def unlink(self, *, from_kb: str, to_kb: str, kind: str) -> bool: ...
     def list_links_for(self, *, name: str, direction: str = "both") -> list[dict[str, Any]]: ...
+
+
+@runtime_checkable
+class ArtifactOpsBackend(GraphBackend, Protocol):
+    """Declarative artifact-graph operations.
+
+    IngestService, ArtifactService, AnnotationService, and RelatesService
+    are typed against this protocol. See m0002 schema in the design spec.
+    """
+
+    # ---- Ingest path ----
+    def upsert_document(self, *, node_id: str, label: str, properties: dict[str, Any]) -> None: ...
+
+    def upsert_artifact(self, *, node_id: str, label: str, properties: dict[str, Any]) -> None: ...
+
+    def delete_artifact(self, *, node_id: str) -> None: ...
+
+    def delete_artifact_with_descendants(self, *, node_id: str) -> list[str]: ...
+
+    def create_contains_edge(self, *, from_id: str, to_id: str) -> None: ...
+
+    def create_relates_edge(
+        self, *, from_id: str, to_id: str, kind: str, properties: dict[str, Any]
+    ) -> None: ...
+
+    def delete_relates_edge(self, *, from_id: str, to_id: str, kind: str) -> bool: ...
+
+    def remove_outbound_relates_rooted_at(self, *, doc_id: str) -> None: ...
+
+    def get_document_snapshot(self, *, doc_id: str) -> list[str]: ...
+
+    def set_document_snapshot(self, *, doc_id: str, node_ids: list[str]) -> None: ...
+
+    def orphan_annotations_for(self, *, node_ids: list[str]) -> None: ...
+
+    # ---- Artifact queries ----
+    def get_artifact(self, *, node_id: str) -> dict[str, Any] | None: ...
+
+    def list_neighbors(
+        self,
+        *,
+        node_id: str,
+        direction: Literal["in", "out", "both"],
+        rel_type: Literal["CONTAINS", "RELATES", "both"],
+        kind: str | None,
+        depth: int,
+        limit: int,
+    ) -> list[dict[str, Any]]: ...
+
+    def find_artifacts(
+        self,
+        *,
+        name: str | None,
+        qualname_prefix: str | None,
+        label: str | None,
+        tag: str | None,
+        kb_name: str | None,
+        limit: int,
+    ) -> list[dict[str, Any]]: ...
+
+    def list_annotations_for(self, *, node_id: str) -> list[dict[str, Any]]: ...
+
+    def list_relates_for(self, *, node_id: str, direction: str) -> list[dict[str, Any]]: ...
+
+    # ---- Annotations ----
+    def create_annotation(
+        self,
+        *,
+        annotation_id: str,
+        target_id: str,
+        target_label: str,
+        kind: str,
+        body: str,
+        tags: list[str],
+        author: str,
+        target_snapshot_json: str,
+    ) -> dict[str, Any]: ...
+
+    def replace_summary_annotation(
+        self,
+        *,
+        annotation_id: str,
+        target_id: str,
+        target_label: str,
+        body: str,
+        tags: list[str],
+        author: str,
+        target_snapshot_json: str,
+    ) -> dict[str, Any]: ...
+
+    def delete_annotation(self, *, annotation_id: str) -> bool: ...
+
+    def list_orphans(self, *, limit: int) -> list[dict[str, Any]]: ...
+
+    def reattach_orphan(self, *, annotation_id: str, new_target_id: str) -> bool: ...
 
 
 class GraphBackendRegistry:

--- a/packages/guru-graph/src/guru_graph/backend/base.py
+++ b/packages/guru-graph/src/guru_graph/backend/base.py
@@ -13,6 +13,21 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, ClassVar, Literal, Protocol, runtime_checkable
 
+# Labels that `upsert_artifact` accepts. `Document` is intentionally excluded —
+# documents go through `upsert_document`. Kept in sync with the m0002 schema.
+ALLOWED_ARTIFACT_LABELS: frozenset[str] = frozenset(
+    {
+        "Module",
+        "Class",
+        "Function",
+        "Method",
+        "OpenApiSpec",
+        "OpenApiOperation",
+        "OpenApiSchema",
+        "MarkdownSection",
+    }
+)
+
 
 @dataclass(frozen=True)
 class BackendInfo:
@@ -101,7 +116,15 @@ class ArtifactOpsBackend(GraphBackend, Protocol):
 
     def delete_artifact(self, *, node_id: str) -> None: ...
 
-    def delete_artifact_with_descendants(self, *, node_id: str) -> list[str]: ...
+    def delete_artifact_with_descendants(self, *, node_id: str) -> list[str]:
+        """Return the ids of `node_id` and all CONTAINS-descendants, without mutating the graph.
+
+        Callers (typically :class:`IngestService`) use this to plan a delete:
+        first collect the subtree, then orphan annotations targeting any node
+        in the subtree, then call :meth:`delete_artifact` for each id. Order
+        of the returned list is unspecified — sort if you need determinism.
+        """
+        ...
 
     def create_contains_edge(self, *, from_id: str, to_id: str) -> None: ...
 

--- a/packages/guru-graph/src/guru_graph/backend/base.py
+++ b/packages/guru-graph/src/guru_graph/backend/base.py
@@ -123,6 +123,7 @@ class ArtifactOpsBackend(GraphBackend, Protocol):
         first collect the subtree, then orphan annotations targeting any node
         in the subtree, then call :meth:`delete_artifact` for each id. Order
         of the returned list is unspecified — sort if you need determinism.
+        Returns an empty list if `node_id` is not present in the graph.
         """
         ...
 

--- a/packages/guru-graph/src/guru_graph/backend/neo4j_backend.py
+++ b/packages/guru-graph/src/guru_graph/backend/neo4j_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 from collections.abc import Iterator
@@ -16,6 +17,19 @@ from ..versioning import check_migration_target
 from .base import BackendHealth, BackendInfo, CypherResult, GraphBackendRegistry, Tx
 
 logger = logging.getLogger(__name__)
+
+_ALLOWED_ARTIFACT_LABELS = frozenset(
+    {
+        "Module",
+        "Class",
+        "Function",
+        "Method",
+        "OpenApiSpec",
+        "OpenApiOperation",
+        "OpenApiSchema",
+        "MarkdownSection",
+    }
+)
 
 
 class _Neo4jTx(Tx):
@@ -331,6 +345,475 @@ class Neo4jBackend:
                 }
                 for r in rs
             ]
+
+    # ---- Declarative artifact helpers (called by artifact services) ----
+    def upsert_document(self, *, node_id: str, label: str, properties: dict[str, Any]) -> None:
+        assert label == "Document", f"upsert_document requires label='Document', got {label!r}"
+        with self._driver.session() as s:
+            s.run(
+                """
+                MERGE (d:Document {id: $id})
+                ON CREATE SET d.created_at = timestamp()
+                SET d += $props
+                SET d.updated_at = timestamp()
+                """,
+                parameters={"id": node_id, "props": dict(properties)},
+            )
+
+    def upsert_artifact(self, *, node_id: str, label: str, properties: dict[str, Any]) -> None:
+        if label == "Document":
+            self.upsert_document(node_id=node_id, label=label, properties=properties)
+            return
+        if label not in _ALLOWED_ARTIFACT_LABELS:
+            raise ValueError(f"unknown artifact label: {label!r}")
+        # Label is from our allow-list, so f-string substitution is safe.
+        cypher = (
+            f"MERGE (n:{label} {{id: $id}}) "
+            "ON CREATE SET n.created_at = timestamp() "
+            "SET n += $props "
+            "SET n.updated_at = timestamp()"
+        )
+        with self._driver.session() as s:
+            s.run(cypher, parameters={"id": node_id, "props": dict(properties)})
+
+    def delete_artifact(self, *, node_id: str) -> None:
+        with self._driver.session() as s:
+            s.run(
+                "MATCH (n {id: $id}) DETACH DELETE n",
+                parameters={"id": node_id},
+            )
+
+    def delete_artifact_with_descendants(self, *, node_id: str) -> list[str]:
+        with self._driver.session() as s:
+            rec = s.run(
+                """
+                MATCH (r {id: $id})
+                OPTIONAL MATCH (r)-[:CONTAINS*0..]->(c)
+                WITH collect(DISTINCT c.id) AS child_ids, r
+                WITH [r.id] + [x IN child_ids WHERE x IS NOT NULL] AS all_ids
+                RETURN all_ids
+                """,
+                parameters={"id": node_id},
+            ).single()
+            if rec is None or rec["all_ids"] is None:
+                return []
+            # Deduplicate in order (root may also appear in child_ids).
+            seen: set[str] = set()
+            out: list[str] = []
+            for x in rec["all_ids"]:
+                if x is None or x in seen:
+                    continue
+                seen.add(x)
+                out.append(x)
+            return out
+
+    def create_contains_edge(self, *, from_id: str, to_id: str) -> None:
+        with self._driver.session() as s:
+            s.run(
+                """
+                MATCH (a {id: $from}), (b {id: $to})
+                MERGE (a)-[:CONTAINS]->(b)
+                """,
+                parameters={"from": from_id, "to": to_id},
+            )
+
+    def create_relates_edge(
+        self, *, from_id: str, to_id: str, kind: str, properties: dict[str, Any]
+    ) -> None:
+        with self._driver.session() as s:
+            s.run(
+                """
+                MATCH (a {id: $from}), (b {id: $to})
+                MERGE (a)-[r:RELATES {kind: $kind}]->(b)
+                ON CREATE SET r.created_at = timestamp()
+                SET r += $props
+                SET r.updated_at = timestamp()
+                """,
+                parameters={
+                    "from": from_id,
+                    "to": to_id,
+                    "kind": kind,
+                    "props": dict(properties),
+                },
+            )
+
+    def delete_relates_edge(self, *, from_id: str, to_id: str, kind: str) -> bool:
+        with self._driver.session() as s:
+            rec = s.run(
+                """
+                MATCH (a {id: $from})-[r:RELATES {kind: $kind}]->(b {id: $to})
+                WITH r, count(r) AS c DELETE r RETURN c
+                """,
+                parameters={"from": from_id, "to": to_id, "kind": kind},
+            ).single()
+            return bool(rec and rec["c"])
+
+    def remove_outbound_relates_rooted_at(self, *, doc_id: str) -> None:
+        with self._driver.session() as s:
+            s.run(
+                """
+                MATCH (d:Document {id: $id})-[:CONTAINS*0..]->(n)
+                OPTIONAL MATCH (n)-[r:RELATES]->()
+                DELETE r
+                """,
+                parameters={"id": doc_id},
+            )
+
+    def get_document_snapshot(self, *, doc_id: str) -> list[str]:
+        with self._driver.session() as s:
+            rec = s.run(
+                "MATCH (d:Document {id: $id}) RETURN d.snapshot_ids_json AS s",
+                parameters={"id": doc_id},
+            ).single()
+            if rec is None or rec["s"] is None:
+                return []
+            try:
+                parsed = json.loads(rec["s"])
+            except (ValueError, TypeError):
+                return []
+            return list(parsed) if isinstance(parsed, list) else []
+
+    def set_document_snapshot(self, *, doc_id: str, node_ids: list[str]) -> None:
+        with self._driver.session() as s:
+            s.run(
+                "MATCH (d:Document {id: $id}) SET d.snapshot_ids_json = $json",
+                parameters={"id": doc_id, "json": json.dumps(list(node_ids))},
+            )
+
+    def orphan_annotations_for(self, *, node_ids: list[str]) -> None:
+        if not node_ids:
+            return
+        with self._driver.session() as s:
+            s.run(
+                """
+                MATCH (a:Annotation)-[:ANNOTATES]->(t)
+                WHERE t.id IN $ids
+                SET a.updated_at = timestamp()
+                """,
+                parameters={"ids": list(node_ids)},
+            )
+            s.run(
+                """
+                MATCH (a:Annotation)-[r:ANNOTATES]->(t)
+                WHERE t.id IN $ids
+                DELETE r
+                """,
+                parameters={"ids": list(node_ids)},
+            )
+
+    def get_artifact(self, *, node_id: str) -> dict[str, Any] | None:
+        with self._driver.session() as s:
+            rec = s.run(
+                "MATCH (n {id: $id}) RETURN labels(n) AS labels, properties(n) AS props",
+                parameters={"id": node_id},
+            ).single()
+            if rec is None:
+                return None
+            labels = [lbl for lbl in (rec["labels"] or []) if not lbl.startswith("_")]
+            if not labels:
+                return None
+            return {
+                "id": node_id,
+                "label": labels[0],
+                "properties": dict(rec["props"] or {}),
+            }
+
+    def list_neighbors(
+        self,
+        *,
+        node_id: str,
+        direction: str,
+        rel_type: str,
+        kind: str | None,
+        depth: int,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        # TODO(PR-4): implement multi-hop + kind filter semantics.
+        # For now, support depth=1 only; if depth > 1 the caller is truncated
+        # with a warning (callers in PR-4/PR-6 will evolve this).
+        if depth > 1:
+            logger.warning("list_neighbors: depth>1 not yet supported; truncating to depth=1")
+        if direction == "out":
+            pattern = "(n {id: $id})-[r]->(m)"
+        elif direction == "in":
+            pattern = "(n {id: $id})<-[r]-(m)"
+        else:
+            pattern = "(n {id: $id})-[r]-(m)"
+        if rel_type == "both":
+            types_clause = "WHERE type(r) IN ['CONTAINS','RELATES']"
+        elif rel_type in ("CONTAINS", "RELATES"):
+            types_clause = f"WHERE type(r) = '{rel_type}'"
+        else:
+            types_clause = "WHERE type(r) IN ['CONTAINS','RELATES']"
+        if kind is not None:
+            types_clause += " AND (type(r) <> 'RELATES' OR r.kind = $kind)"
+        cypher = (
+            f"MATCH {pattern} {types_clause} "
+            "RETURN m.id AS id, labels(m)[0] AS label, type(r) AS rel_type, "
+            "       r.kind AS kind, 1 AS distance "
+            "LIMIT $limit"
+        )
+        params: dict[str, Any] = {"id": node_id, "limit": limit}
+        if kind is not None:
+            params["kind"] = kind
+        with self._driver.session() as s:
+            rs = s.run(cypher, parameters=params)
+            return [
+                {
+                    "id": r["id"],
+                    "label": r["label"],
+                    "rel_type": r["rel_type"],
+                    "kind": r["kind"],
+                    "distance": r["distance"],
+                }
+                for r in rs
+            ]
+
+    def find_artifacts(
+        self,
+        *,
+        name: str | None,
+        qualname_prefix: str | None,
+        label: str | None,
+        tag: str | None,
+        kb_name: str | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"limit": limit}
+        if label is not None:
+            if label != "Document" and label not in _ALLOWED_ARTIFACT_LABELS:
+                raise ValueError(f"unknown artifact label: {label!r}")
+            match_clause = f"MATCH (n:{label})"
+        else:
+            match_clause = "MATCH (n)"
+        filters: list[str] = []
+        if name is not None:
+            filters.append("n.name = $name")
+            params["name"] = name
+        if qualname_prefix is not None:
+            filters.append("n.qualname STARTS WITH $qualname_prefix")
+            params["qualname_prefix"] = qualname_prefix
+        if tag is not None:
+            filters.append("$tag IN n.tags")
+            params["tag"] = tag
+        if kb_name is not None:
+            filters.append("n.kb_name = $kb_name")
+            params["kb_name"] = kb_name
+        # Always filter out schema/meta nodes.
+        filters.append("NOT any(lbl IN labels(n) WHERE lbl STARTS WITH '_')")
+        where = "WHERE " + " AND ".join(filters)
+        cypher = (
+            f"{match_clause} {where} "
+            "RETURN n.id AS id, labels(n) AS labels, properties(n) AS props "
+            "LIMIT $limit"
+        )
+        with self._driver.session() as s:
+            rs = s.run(cypher, parameters=params)
+            out: list[dict[str, Any]] = []
+            for r in rs:
+                labels = [lbl for lbl in (r["labels"] or []) if not lbl.startswith("_")]
+                if not labels:
+                    continue
+                out.append(
+                    {
+                        "id": r["id"],
+                        "label": labels[0],
+                        "properties": dict(r["props"] or {}),
+                    }
+                )
+            return out
+
+    def list_annotations_for(self, *, node_id: str) -> list[dict[str, Any]]:
+        with self._driver.session() as s:
+            rs = s.run(
+                """
+                MATCH (a:Annotation)-[:ANNOTATES]->(t {id: $id})
+                RETURN a.id AS annotation_id, t.id AS target_id, labels(t)[0] AS target_label,
+                       a.kind AS kind, a.body AS body, a.tags AS tags, a.author AS author,
+                       a.created_at AS created_at, a.updated_at AS updated_at,
+                       a.target_snapshot_json AS target_snapshot_json
+                """,
+                parameters={"id": node_id},
+            )
+            return [_annotation_row_to_dict(r) for r in rs]
+
+    def list_relates_for(self, *, node_id: str, direction: str) -> list[dict[str, Any]]:
+        if direction == "out":
+            cypher = (
+                "MATCH (a {id: $id})-[r:RELATES]->(b) "
+                "RETURN a.id AS from_id, b.id AS to_id, r.kind AS kind, "
+                "       properties(r) AS props"
+            )
+        elif direction == "in":
+            cypher = (
+                "MATCH (a)-[r:RELATES]->(b {id: $id}) "
+                "RETURN a.id AS from_id, b.id AS to_id, r.kind AS kind, "
+                "       properties(r) AS props"
+            )
+        else:
+            cypher = (
+                "MATCH (a)-[r:RELATES]->(b) "
+                "WHERE a.id = $id OR b.id = $id "
+                "RETURN a.id AS from_id, b.id AS to_id, r.kind AS kind, "
+                "       properties(r) AS props"
+            )
+        with self._driver.session() as s:
+            rs = s.run(cypher, parameters={"id": node_id})
+            return [
+                {
+                    "from_id": r["from_id"],
+                    "to_id": r["to_id"],
+                    "kind": r["kind"],
+                    "properties": dict(r["props"] or {}),
+                }
+                for r in rs
+            ]
+
+    def create_annotation(
+        self,
+        *,
+        annotation_id: str,
+        target_id: str,
+        target_label: str,
+        kind: str,
+        body: str,
+        tags: list[str],
+        author: str,
+        target_snapshot_json: str,
+    ) -> dict[str, Any]:
+        with self._driver.session() as s:
+            rec = s.run(
+                """
+                MATCH (t {id: $target_id})
+                CREATE (a:Annotation {
+                    id: $annotation_id,
+                    kind: $kind,
+                    body: $body,
+                    tags: $tags,
+                    author: $author,
+                    target_snapshot_json: $snap,
+                    created_at: timestamp(),
+                    updated_at: timestamp()
+                })
+                CREATE (a)-[:ANNOTATES]->(t)
+                RETURN a.id AS annotation_id, t.id AS target_id, labels(t)[0] AS target_label,
+                       a.kind AS kind, a.body AS body, a.tags AS tags, a.author AS author,
+                       a.created_at AS created_at, a.updated_at AS updated_at,
+                       a.target_snapshot_json AS target_snapshot_json
+                """,
+                parameters={
+                    "annotation_id": annotation_id,
+                    "target_id": target_id,
+                    "kind": kind,
+                    "body": body,
+                    "tags": list(tags),
+                    "author": author,
+                    "snap": target_snapshot_json,
+                },
+            ).single()
+            if rec is None:
+                raise KeyError(f"target {target_id!r} not found")
+            return _annotation_row_to_dict(rec)
+
+    def replace_summary_annotation(
+        self,
+        *,
+        annotation_id: str,
+        target_id: str,
+        target_label: str,
+        body: str,
+        tags: list[str],
+        author: str,
+        target_snapshot_json: str,
+    ) -> dict[str, Any]:
+        with self._driver.session() as s:
+            rec = s.run(
+                """
+                MATCH (t {id: $target_id})
+                MERGE (a:Annotation {id: $annotation_id})
+                ON CREATE SET a.kind = 'summary', a.body = $body, a.tags = $tags,
+                              a.author = $author, a.target_snapshot_json = $snap,
+                              a.created_at = timestamp(), a.updated_at = timestamp()
+                ON MATCH SET a.kind = 'summary', a.body = $body, a.tags = $tags,
+                             a.author = $author, a.target_snapshot_json = $snap,
+                             a.updated_at = timestamp()
+                MERGE (a)-[:ANNOTATES]->(t)
+                RETURN a.id AS annotation_id, t.id AS target_id, labels(t)[0] AS target_label,
+                       a.kind AS kind, a.body AS body, a.tags AS tags, a.author AS author,
+                       a.created_at AS created_at, a.updated_at AS updated_at,
+                       a.target_snapshot_json AS target_snapshot_json
+                """,
+                parameters={
+                    "annotation_id": annotation_id,
+                    "target_id": target_id,
+                    "body": body,
+                    "tags": list(tags),
+                    "author": author,
+                    "snap": target_snapshot_json,
+                },
+            ).single()
+            if rec is None:
+                raise KeyError(f"target {target_id!r} not found")
+            return _annotation_row_to_dict(rec)
+
+    def delete_annotation(self, *, annotation_id: str) -> bool:
+        with self._driver.session() as s:
+            rec = s.run(
+                """
+                MATCH (a:Annotation {id: $id})
+                WITH a, count(a) AS c DETACH DELETE a RETURN c
+                """,
+                parameters={"id": annotation_id},
+            ).single()
+            return bool(rec and rec["c"])
+
+    def list_orphans(self, *, limit: int) -> list[dict[str, Any]]:
+        with self._driver.session() as s:
+            rs = s.run(
+                """
+                MATCH (a:Annotation)
+                WHERE NOT (a)-[:ANNOTATES]->()
+                RETURN a.id AS annotation_id, NULL AS target_id, NULL AS target_label,
+                       a.kind AS kind, a.body AS body, a.tags AS tags, a.author AS author,
+                       a.created_at AS created_at, a.updated_at AS updated_at,
+                       a.target_snapshot_json AS target_snapshot_json
+                LIMIT $limit
+                """,
+                parameters={"limit": limit},
+            )
+            return [_annotation_row_to_dict(r) for r in rs]
+
+    def reattach_orphan(self, *, annotation_id: str, new_target_id: str) -> bool:
+        with self._driver.session() as s:
+            rec = s.run(
+                """
+                MATCH (a:Annotation {id: $aid})
+                WHERE NOT (a)-[:ANNOTATES]->()
+                MATCH (t {id: $tid})
+                MERGE (a)-[:ANNOTATES]->(t)
+                SET a.updated_at = timestamp()
+                RETURN count(t) AS c
+                """,
+                parameters={"aid": annotation_id, "tid": new_target_id},
+            ).single()
+            return bool(rec and rec["c"])
+
+
+def _annotation_row_to_dict(rec) -> dict[str, Any]:
+    created = rec["created_at"]
+    updated = rec["updated_at"]
+    return {
+        "annotation_id": rec["annotation_id"],
+        "target_id": rec["target_id"],
+        "target_label": rec["target_label"],
+        "kind": rec["kind"],
+        "body": rec["body"],
+        "tags": list(rec["tags"] or []),
+        "author": rec["author"],
+        "created_at": created / 1000.0 if created is not None else None,
+        "updated_at": updated / 1000.0 if updated is not None else None,
+        "target_snapshot_json": rec["target_snapshot_json"],
+    }
 
 
 GraphBackendRegistry.register("neo4j", Neo4jBackend)

--- a/packages/guru-graph/src/guru_graph/backend/neo4j_backend.py
+++ b/packages/guru-graph/src/guru_graph/backend/neo4j_backend.py
@@ -14,22 +14,16 @@ from neo4j import GraphDatabase
 
 from ..neo4j_process import Neo4jRuntime, start_neo4j, stop_neo4j
 from ..versioning import check_migration_target
-from .base import BackendHealth, BackendInfo, CypherResult, GraphBackendRegistry, Tx
+from .base import (
+    ALLOWED_ARTIFACT_LABELS,
+    BackendHealth,
+    BackendInfo,
+    CypherResult,
+    GraphBackendRegistry,
+    Tx,
+)
 
 logger = logging.getLogger(__name__)
-
-_ALLOWED_ARTIFACT_LABELS = frozenset(
-    {
-        "Module",
-        "Class",
-        "Function",
-        "Method",
-        "OpenApiSpec",
-        "OpenApiOperation",
-        "OpenApiSchema",
-        "MarkdownSection",
-    }
-)
 
 
 class _Neo4jTx(Tx):
@@ -364,7 +358,7 @@ class Neo4jBackend:
         if label == "Document":
             self.upsert_document(node_id=node_id, label=label, properties=properties)
             return
-        if label not in _ALLOWED_ARTIFACT_LABELS:
+        if label not in ALLOWED_ARTIFACT_LABELS:
             raise ValueError(f"unknown artifact label: {label!r}")
         # Label is from our allow-list, so f-string substitution is safe.
         cypher = (
@@ -384,6 +378,7 @@ class Neo4jBackend:
             )
 
     def delete_artifact_with_descendants(self, *, node_id: str) -> list[str]:
+        """See :meth:`ArtifactOpsBackend.delete_artifact_with_descendants`."""
         with self._driver.session() as s:
             rec = s.run(
                 """
@@ -483,22 +478,15 @@ class Neo4jBackend:
     def orphan_annotations_for(self, *, node_ids: list[str]) -> None:
         if not node_ids:
             return
-        with self._driver.session() as s:
-            s.run(
-                """
-                MATCH (a:Annotation)-[:ANNOTATES]->(t)
-                WHERE t.id IN $ids
-                SET a.updated_at = timestamp()
-                """,
-                parameters={"ids": list(node_ids)},
+        with self.transaction() as tx:
+            tx.execute(
+                "MATCH (a:Annotation)-[:ANNOTATES]->(t) WHERE t.id IN $ids "
+                "SET a.updated_at = timestamp()",
+                {"ids": list(node_ids)},
             )
-            s.run(
-                """
-                MATCH (a:Annotation)-[r:ANNOTATES]->(t)
-                WHERE t.id IN $ids
-                DELETE r
-                """,
-                parameters={"ids": list(node_ids)},
+            tx.execute(
+                "MATCH (a:Annotation)-[r:ANNOTATES]->(t) WHERE t.id IN $ids DELETE r",
+                {"ids": list(node_ids)},
             )
 
     def get_artifact(self, *, node_id: str) -> dict[str, Any] | None:
@@ -581,7 +569,7 @@ class Neo4jBackend:
     ) -> list[dict[str, Any]]:
         params: dict[str, Any] = {"limit": limit}
         if label is not None:
-            if label != "Document" and label not in _ALLOWED_ARTIFACT_LABELS:
+            if label != "Document" and label not in ALLOWED_ARTIFACT_LABELS:
                 raise ValueError(f"unknown artifact label: {label!r}")
             match_clause = f"MATCH (n:{label})"
         else:

--- a/packages/guru-graph/src/guru_graph/migrations/__init__.py
+++ b/packages/guru-graph/src/guru_graph/migrations/__init__.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from typing import Any
 
 from .m0001_initial import apply as m0001
+from .m0002_artifact_schema import apply as m0002
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,7 @@ Migration = Callable[[Any], None]
 
 MIGRATIONS: list[tuple[int, Migration]] = [
     (1, m0001),
+    (2, m0002),
 ]
 
 

--- a/packages/guru-graph/src/guru_graph/migrations/m0002_artifact_schema.py
+++ b/packages/guru-graph/src/guru_graph/migrations/m0002_artifact_schema.py
@@ -1,0 +1,52 @@
+"""m0002 — artifact-graph schema (schema_version 1 -> 2).
+
+Adds uniqueness constraints for (:Document), (:Module), (:Class), (:Function),
+(:Method), (:OpenApiSpec), (:OpenApiOperation), (:OpenApiSchema),
+(:MarkdownSection), (:Annotation); adds indexes used by hot query paths.
+
+Forward-only and idempotent: every step uses `IF NOT EXISTS` / `MERGE`, so
+re-running the migration against a store that already contains the new
+schema is a no-op. The migration registry (`run_pending_migrations`)
+filters by version, so direct re-invocation of `apply()` against a higher
+version store is still safe.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+CYPHER_STEPS = [
+    # Uniqueness constraints for artifact-graph nodes.
+    "CREATE CONSTRAINT document_id_unique IF NOT EXISTS FOR (d:Document) REQUIRE d.id IS UNIQUE",
+    "CREATE CONSTRAINT module_id_unique IF NOT EXISTS FOR (m:Module) REQUIRE m.id IS UNIQUE",
+    "CREATE CONSTRAINT class_id_unique IF NOT EXISTS FOR (c:Class) REQUIRE c.id IS UNIQUE",
+    "CREATE CONSTRAINT function_id_unique IF NOT EXISTS FOR (f:Function) REQUIRE f.id IS UNIQUE",
+    "CREATE CONSTRAINT method_id_unique IF NOT EXISTS FOR (m:Method) REQUIRE m.id IS UNIQUE",
+    "CREATE CONSTRAINT oas_spec_id_unique IF NOT EXISTS FOR (s:OpenApiSpec) REQUIRE s.id IS UNIQUE",
+    "CREATE CONSTRAINT oas_op_id_unique IF NOT EXISTS "
+    "FOR (o:OpenApiOperation) REQUIRE o.id IS UNIQUE",
+    "CREATE CONSTRAINT oas_schema_id_unique IF NOT EXISTS "
+    "FOR (s:OpenApiSchema) REQUIRE s.id IS UNIQUE",
+    "CREATE CONSTRAINT md_section_id_unique IF NOT EXISTS "
+    "FOR (s:MarkdownSection) REQUIRE s.id IS UNIQUE",
+    "CREATE CONSTRAINT annotation_id_unique IF NOT EXISTS "
+    "FOR (a:Annotation) REQUIRE a.id IS UNIQUE",
+    # Indexes for hot query paths.
+    "CREATE INDEX document_kb_name IF NOT EXISTS FOR (d:Document) ON (d.kb_name)",
+    "CREATE INDEX document_language IF NOT EXISTS FOR (d:Document) ON (d.language)",
+    "CREATE INDEX annotation_kind IF NOT EXISTS FOR (a:Annotation) ON (a.kind)",
+    "CREATE INDEX annotation_author IF NOT EXISTS FOR (a:Annotation) ON (a.author)",
+    "CREATE INDEX module_qualname IF NOT EXISTS FOR (m:Module) ON (m.qualname)",
+    "CREATE INDEX class_qualname IF NOT EXISTS FOR (c:Class) ON (c.qualname)",
+    "CREATE INDEX function_qualname IF NOT EXISTS FOR (f:Function) ON (f.qualname)",
+    "CREATE INDEX method_qualname IF NOT EXISTS FOR (m:Method) ON (m.qualname)",
+    # Bump (:_Meta {kind:'schema'}).schema_version to 2.
+    "MERGE (m:_Meta {kind: 'schema'}) "
+    "ON CREATE SET m.schema_version = 2, m.created_at = timestamp() "
+    "ON MATCH SET m.schema_version = 2, m.updated_at = timestamp()",
+]
+
+
+def apply(backend: Any) -> None:
+    for step in CYPHER_STEPS:
+        backend.execute(step, {})

--- a/packages/guru-graph/src/guru_graph/routes/ingest.py
+++ b/packages/guru-graph/src/guru_graph/routes/ingest.py
@@ -1,0 +1,43 @@
+"""Ingestion routes consumed by guru-server. Not exposed to MCP.
+
+Endpoints:
+- POST /ingest/parse-result?kb_name=...  — apply ParseResultPayload
+- DELETE /ingest/documents/{doc_id}?kb_name=...  — remove Document + subtree
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request, Response, status
+
+from guru_core.graph_types import ParseResultPayload
+
+from ..services.ingest_service import IngestService
+
+router = APIRouter()
+
+
+def _svc(request: Request) -> IngestService:
+    return IngestService(backend=request.app.state.backend)
+
+
+@router.post("/ingest/parse-result", status_code=status.HTTP_204_NO_CONTENT)
+def submit_parse_result(
+    payload: ParseResultPayload,
+    request: Request,
+    kb_name: str,
+) -> Response:
+    _svc(request).submit(kb_name, payload)
+    return Response(status_code=204)
+
+
+@router.delete(
+    "/ingest/documents/{doc_id:path}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_document(
+    doc_id: str,
+    request: Request,
+    kb_name: str,
+) -> Response:
+    _svc(request).delete_document(kb_name, doc_id)
+    return Response(status_code=204)

--- a/packages/guru-graph/src/guru_graph/services/ingest_service.py
+++ b/packages/guru-graph/src/guru_graph/services/ingest_service.py
@@ -1,0 +1,96 @@
+"""Reconciliation service: apply ParseResult payloads idempotently.
+
+The service sits above :class:`ArtifactOpsBackend`. It expresses the
+semantic contract:
+
+  - Upsert document + sub-artifacts in the payload
+  - Remove artifacts that disappeared between parses (via stored Document
+    snapshot), orphaning any annotations targeting them
+  - Replace outbound RELATES edges rooted at the document (they are
+    recomputed from scratch each parse)
+
+Orphan-preserving deletion: annotations targeting a deleted node have
+their :ANNOTATES edge removed but the annotation node itself is preserved
+for agent triage (:meth:`ArtifactOpsBackend.orphan_annotations_for`).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from guru_core.graph_types import ParseResultPayload
+
+from ..backend.base import ArtifactOpsBackend
+
+logger = logging.getLogger(__name__)
+
+
+class IngestService:
+    def __init__(self, *, backend: ArtifactOpsBackend) -> None:
+        self._backend = backend
+
+    def submit(self, kb_name: str, payload: ParseResultPayload) -> None:
+        """Reconcile a Document + its sub-artifacts to the graph.
+
+        `kb_name` is currently carried for logging/future multi-tenancy
+        checks; the document's node_id already encodes the kb (`{kb}::{rel_path}`).
+        """
+        doc_id = payload.document.node_id
+        prev_ids = set(self._backend.get_document_snapshot(doc_id=doc_id))
+        current_ids = {n.node_id for n in payload.nodes}
+
+        # Step 1: compute victims (artifacts that disappeared) + their descendants
+        to_delete_roots = list(prev_ids - current_ids)
+        if to_delete_roots:
+            all_victims: list[str] = []
+            for nid in to_delete_roots:
+                all_victims.extend(self._backend.delete_artifact_with_descendants(node_id=nid))
+            if all_victims:
+                # Orphan annotations BEFORE deleting, so the annotation
+                # loses its :ANNOTATES edge but survives.
+                self._backend.orphan_annotations_for(node_ids=all_victims)
+                for nid in all_victims:
+                    self._backend.delete_artifact(node_id=nid)
+
+        # Step 2: upsert document + every sub-artifact
+        self._backend.upsert_document(
+            node_id=doc_id,
+            label=payload.document.label,
+            properties=payload.document.properties,
+        )
+        for n in payload.nodes:
+            self._backend.upsert_artifact(
+                node_id=n.node_id,
+                label=n.label,
+                properties=n.properties,
+            )
+
+        # Step 3: replace outbound RELATES rooted at this document
+        self._backend.remove_outbound_relates_rooted_at(doc_id=doc_id)
+        for e in payload.edges:
+            if e.rel_type == "CONTAINS":
+                self._backend.create_contains_edge(from_id=e.from_id, to_id=e.to_id)
+            else:  # "RELATES"
+                assert e.kind is not None  # Pydantic validator ensures this
+                self._backend.create_relates_edge(
+                    from_id=e.from_id,
+                    to_id=e.to_id,
+                    kind=e.kind,
+                    properties=e.properties,
+                )
+
+        # Step 4: record new snapshot (sorted for deterministic order)
+        self._backend.set_document_snapshot(doc_id=doc_id, node_ids=sorted(current_ids))
+
+    def delete_document(self, kb_name: str, doc_id: str) -> None:
+        """Remove a document and its entire CONTAINS subtree.
+
+        Annotations targeting any deleted node are orphaned (target_id → None).
+        Safe to call on a non-existent document (no-op).
+        """
+        victims = self._backend.delete_artifact_with_descendants(node_id=doc_id)
+        if not victims:
+            return
+        self._backend.orphan_annotations_for(node_ids=victims)
+        for nid in victims:
+            self._backend.delete_artifact(node_id=nid)

--- a/packages/guru-graph/src/guru_graph/services/ingest_service.py
+++ b/packages/guru-graph/src/guru_graph/services/ingest_service.py
@@ -35,6 +35,17 @@ class IngestService:
         `kb_name` is currently carried for logging/future multi-tenancy
         checks; the document's node_id already encodes the kb (`{kb}::{rel_path}`).
         """
+        # Non-transactional: backend calls run in sequence. A mid-sequence failure
+        # can leave the graph partially updated (e.g. upsert completes, snapshot
+        # not written). Next submit will re-diff from the stale snapshot and
+        # self-heal. See Task 2.5 review for context.
+        logger.debug(
+            "ingest.submit kb=%s doc_id=%s nodes=%d edges=%d",
+            kb_name,
+            payload.document.node_id,
+            len(payload.nodes),
+            len(payload.edges),
+        )
         doc_id = payload.document.node_id
         prev_ids = set(self._backend.get_document_snapshot(doc_id=doc_id))
         current_ids = {n.node_id for n in payload.nodes}
@@ -45,6 +56,9 @@ class IngestService:
             all_victims: list[str] = []
             for nid in to_delete_roots:
                 all_victims.extend(self._backend.delete_artifact_with_descendants(node_id=nid))
+            # Deduplicate while preserving first-seen order (diamonds in CONTAINS are
+            # unlikely but not structurally forbidden).
+            all_victims = list(dict.fromkeys(all_victims))
             if all_victims:
                 # Orphan annotations BEFORE deleting, so the annotation
                 # loses its :ANNOTATES edge but survives.
@@ -71,7 +85,9 @@ class IngestService:
             if e.rel_type == "CONTAINS":
                 self._backend.create_contains_edge(from_id=e.from_id, to_id=e.to_id)
             else:  # "RELATES"
-                assert e.kind is not None  # Pydantic validator ensures this
+                if e.kind is None:
+                    # Pydantic validator should have rejected this upstream; guard for -O runs.
+                    raise ValueError(f"RELATES edge from {e.from_id} to {e.to_id} missing kind")
                 self._backend.create_relates_edge(
                     from_id=e.from_id,
                     to_id=e.to_id,
@@ -88,6 +104,7 @@ class IngestService:
         Annotations targeting any deleted node are orphaned (target_id → None).
         Safe to call on a non-existent document (no-op).
         """
+        logger.debug("ingest.delete_document kb=%s doc_id=%s", kb_name, doc_id)
         victims = self._backend.delete_artifact_with_descendants(node_id=doc_id)
         if not victims:
             return

--- a/packages/guru-graph/src/guru_graph/testing/fake_backend.py
+++ b/packages/guru-graph/src/guru_graph/testing/fake_backend.py
@@ -14,21 +14,14 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any
 
-from guru_graph.backend.base import BackendHealth, BackendInfo, CypherResult, Tx
-from guru_graph.versioning import check_migration_target
-
-_ALLOWED_ARTIFACT_LABELS = frozenset(
-    {
-        "Module",
-        "Class",
-        "Function",
-        "Method",
-        "OpenApiSpec",
-        "OpenApiOperation",
-        "OpenApiSchema",
-        "MarkdownSection",
-    }
+from guru_graph.backend.base import (
+    ALLOWED_ARTIFACT_LABELS,
+    BackendHealth,
+    BackendInfo,
+    CypherResult,
+    Tx,
 )
+from guru_graph.versioning import check_migration_target
 
 
 @dataclass
@@ -214,7 +207,7 @@ class FakeBackend:
         )
 
     def upsert_artifact(self, *, node_id: str, label: str, properties: dict[str, Any]) -> None:
-        if label != "Document" and label not in _ALLOWED_ARTIFACT_LABELS:
+        if label != "Document" and label not in ALLOWED_ARTIFACT_LABELS:
             raise ValueError(f"unknown artifact label: {label!r}")
         existing = self._artifacts.get(node_id)
         snapshot = list(existing.snapshot_ids) if existing is not None else []
@@ -230,6 +223,7 @@ class FakeBackend:
         self._edges = [e for e in self._edges if e.from_id != node_id and e.to_id != node_id]
 
     def delete_artifact_with_descendants(self, *, node_id: str) -> list[str]:
+        """See :meth:`ArtifactOpsBackend.delete_artifact_with_descendants`."""
         # BFS over CONTAINS edges starting from node_id.
         result: list[str] = [node_id]
         seen: set[str] = {node_id}

--- a/packages/guru-graph/src/guru_graph/testing/fake_backend.py
+++ b/packages/guru-graph/src/guru_graph/testing/fake_backend.py
@@ -17,6 +17,19 @@ from typing import Any
 from guru_graph.backend.base import BackendHealth, BackendInfo, CypherResult, Tx
 from guru_graph.versioning import check_migration_target
 
+_ALLOWED_ARTIFACT_LABELS = frozenset(
+    {
+        "Module",
+        "Class",
+        "Function",
+        "Method",
+        "OpenApiSpec",
+        "OpenApiOperation",
+        "OpenApiSchema",
+        "MarkdownSection",
+    }
+)
+
 
 @dataclass
 class _FakeLink:
@@ -25,6 +38,37 @@ class _FakeLink:
     kind: str
     created_at: float
     metadata_json: str
+
+
+@dataclass
+class _FakeArtifact:
+    node_id: str
+    label: str
+    properties: dict[str, Any]
+    snapshot_ids: list[str] = field(default_factory=list)  # Document-only
+
+
+@dataclass
+class _FakeEdge:
+    from_id: str
+    to_id: str
+    rel_type: str  # "CONTAINS" | "RELATES"
+    kind: str | None
+    properties: dict[str, Any]
+
+
+@dataclass
+class _FakeAnnotation:
+    annotation_id: str
+    target_id: str | None
+    target_label: str | None
+    kind: str
+    body: str
+    tags: list[str]
+    author: str
+    created_at: float
+    updated_at: float
+    target_snapshot_json: str
 
 
 @dataclass
@@ -37,6 +81,9 @@ class FakeBackend:
 
     _nodes: dict[str, dict[str, Any]] = field(default_factory=dict)
     _links: list[_FakeLink] = field(default_factory=list)
+    _artifacts: dict[str, _FakeArtifact] = field(default_factory=dict)
+    _edges: list[_FakeEdge] = field(default_factory=list)
+    _annotations: dict[str, _FakeAnnotation] = field(default_factory=dict)
     _started: bool = False
     _schema_version: int = 0
 
@@ -153,3 +200,379 @@ class FakeBackend:
                     }
                 )
         return out
+
+    # ---- Artifact ingest ops ----
+    def upsert_document(self, *, node_id: str, label: str, properties: dict[str, Any]) -> None:
+        assert label == "Document", f"upsert_document requires label='Document', got {label!r}"
+        existing = self._artifacts.get(node_id)
+        snapshot = list(existing.snapshot_ids) if existing is not None else []
+        self._artifacts[node_id] = _FakeArtifact(
+            node_id=node_id,
+            label=label,
+            properties=dict(properties),
+            snapshot_ids=snapshot,
+        )
+
+    def upsert_artifact(self, *, node_id: str, label: str, properties: dict[str, Any]) -> None:
+        if label != "Document" and label not in _ALLOWED_ARTIFACT_LABELS:
+            raise ValueError(f"unknown artifact label: {label!r}")
+        existing = self._artifacts.get(node_id)
+        snapshot = list(existing.snapshot_ids) if existing is not None else []
+        self._artifacts[node_id] = _FakeArtifact(
+            node_id=node_id,
+            label=label,
+            properties=dict(properties),
+            snapshot_ids=snapshot,
+        )
+
+    def delete_artifact(self, *, node_id: str) -> None:
+        self._artifacts.pop(node_id, None)
+        self._edges = [e for e in self._edges if e.from_id != node_id and e.to_id != node_id]
+
+    def delete_artifact_with_descendants(self, *, node_id: str) -> list[str]:
+        # BFS over CONTAINS edges starting from node_id.
+        result: list[str] = [node_id]
+        seen: set[str] = {node_id}
+        queue: list[str] = [node_id]
+        while queue:
+            current = queue.pop(0)
+            for edge in self._edges:
+                if (
+                    edge.rel_type == "CONTAINS"
+                    and edge.from_id == current
+                    and edge.to_id not in seen
+                ):
+                    seen.add(edge.to_id)
+                    result.append(edge.to_id)
+                    queue.append(edge.to_id)
+        return result
+
+    def create_contains_edge(self, *, from_id: str, to_id: str) -> None:
+        for edge in self._edges:
+            if edge.rel_type == "CONTAINS" and edge.from_id == from_id and edge.to_id == to_id:
+                return
+        self._edges.append(
+            _FakeEdge(
+                from_id=from_id,
+                to_id=to_id,
+                rel_type="CONTAINS",
+                kind=None,
+                properties={},
+            )
+        )
+
+    def create_relates_edge(
+        self, *, from_id: str, to_id: str, kind: str, properties: dict[str, Any]
+    ) -> None:
+        for edge in self._edges:
+            if (
+                edge.rel_type == "RELATES"
+                and edge.from_id == from_id
+                and edge.to_id == to_id
+                and edge.kind == kind
+            ):
+                edge.properties = dict(properties)
+                return
+        self._edges.append(
+            _FakeEdge(
+                from_id=from_id,
+                to_id=to_id,
+                rel_type="RELATES",
+                kind=kind,
+                properties=dict(properties),
+            )
+        )
+
+    def delete_relates_edge(self, *, from_id: str, to_id: str, kind: str) -> bool:
+        before = len(self._edges)
+        self._edges = [
+            edge
+            for edge in self._edges
+            if not (
+                edge.rel_type == "RELATES"
+                and edge.from_id == from_id
+                and edge.to_id == to_id
+                and edge.kind == kind
+            )
+        ]
+        return len(self._edges) < before
+
+    def remove_outbound_relates_rooted_at(self, *, doc_id: str) -> None:
+        # Collect all nodes reachable via CONTAINS* from doc_id (including doc_id).
+        reachable: set[str] = {doc_id}
+        queue: list[str] = [doc_id]
+        while queue:
+            current = queue.pop(0)
+            for edge in self._edges:
+                if (
+                    edge.rel_type == "CONTAINS"
+                    and edge.from_id == current
+                    and edge.to_id not in reachable
+                ):
+                    reachable.add(edge.to_id)
+                    queue.append(edge.to_id)
+        self._edges = [
+            edge
+            for edge in self._edges
+            if not (edge.rel_type == "RELATES" and edge.from_id in reachable)
+        ]
+
+    def get_document_snapshot(self, *, doc_id: str) -> list[str]:
+        art = self._artifacts.get(doc_id)
+        if art is None:
+            return []
+        return list(art.snapshot_ids)
+
+    def set_document_snapshot(self, *, doc_id: str, node_ids: list[str]) -> None:
+        art = self._artifacts[doc_id]  # KeyError if missing, as documented.
+        art.snapshot_ids = list(node_ids)
+
+    def orphan_annotations_for(self, *, node_ids: list[str]) -> None:
+        ids = set(node_ids)
+        now = time.time()
+        for ann in self._annotations.values():
+            if ann.target_id in ids:
+                ann.target_id = None
+                ann.target_label = None
+                ann.updated_at = now
+
+    # ---- Artifact queries ----
+    def get_artifact(self, *, node_id: str) -> dict[str, Any] | None:
+        art = self._artifacts.get(node_id)
+        if art is None:
+            return None
+        return {
+            "id": art.node_id,
+            "label": art.label,
+            "properties": copy.deepcopy(art.properties),
+        }
+
+    def list_neighbors(
+        self,
+        *,
+        node_id: str,
+        direction: str,
+        rel_type: str,
+        kind: str | None,
+        depth: int,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        if depth <= 0:
+            depth = 1
+        # BFS walking _edges respecting direction + rel_type + kind filter.
+        results: list[dict[str, Any]] = []
+        visited: set[str] = {node_id}
+        frontier: list[tuple[str, int]] = [(node_id, 0)]
+        while frontier and len(results) < limit:
+            current, dist = frontier.pop(0)
+            if dist >= depth:
+                continue
+            for edge in self._edges:
+                # Respect rel_type filter.
+                if rel_type != "both" and edge.rel_type != rel_type:
+                    continue
+                # Respect kind filter (only applies to RELATES).
+                if kind is not None and edge.rel_type == "RELATES" and edge.kind != kind:
+                    continue
+                # Respect direction.
+                neighbor_id: str | None = None
+                if direction in ("out", "both") and edge.from_id == current:
+                    neighbor_id = edge.to_id
+                elif direction in ("in", "both") and edge.to_id == current:
+                    neighbor_id = edge.from_id
+                else:
+                    continue
+                if neighbor_id in visited:
+                    continue
+                visited.add(neighbor_id)
+                art = self._artifacts.get(neighbor_id)
+                neighbor_label = art.label if art is not None else None
+                results.append(
+                    {
+                        "id": neighbor_id,
+                        "label": neighbor_label,
+                        "rel_type": edge.rel_type,
+                        "kind": edge.kind,
+                        "distance": dist + 1,
+                    }
+                )
+                if len(results) >= limit:
+                    break
+                frontier.append((neighbor_id, dist + 1))
+        return results
+
+    def find_artifacts(
+        self,
+        *,
+        name: str | None,
+        qualname_prefix: str | None,
+        label: str | None,
+        tag: str | None,
+        kb_name: str | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        for art in self._artifacts.values():
+            if name is not None and art.properties.get("name") != name:
+                continue
+            if qualname_prefix is not None and not str(
+                art.properties.get("qualname", "")
+            ).startswith(qualname_prefix):
+                continue
+            if label is not None and art.label != label:
+                continue
+            if tag is not None and tag not in (art.properties.get("tags") or []):
+                continue
+            if kb_name is not None and art.properties.get("kb_name") != kb_name:
+                continue
+            results.append(
+                {
+                    "id": art.node_id,
+                    "label": art.label,
+                    "properties": copy.deepcopy(art.properties),
+                }
+            )
+            if len(results) >= limit:
+                break
+        return results
+
+    def list_annotations_for(self, *, node_id: str) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for ann in self._annotations.values():
+            if ann.target_id == node_id:
+                out.append(_annotation_to_dict(ann))
+        return out
+
+    def list_relates_for(self, *, node_id: str, direction: str) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for edge in self._edges:
+            if edge.rel_type != "RELATES":
+                continue
+            include = (direction in ("out", "both") and edge.from_id == node_id) or (
+                direction in ("in", "both") and edge.to_id == node_id
+            )
+            if include:
+                out.append(
+                    {
+                        "from_id": edge.from_id,
+                        "to_id": edge.to_id,
+                        "kind": edge.kind,
+                        "properties": copy.deepcopy(edge.properties),
+                    }
+                )
+        return out
+
+    # ---- Annotations ----
+    def create_annotation(
+        self,
+        *,
+        annotation_id: str,
+        target_id: str,
+        target_label: str,
+        kind: str,
+        body: str,
+        tags: list[str],
+        author: str,
+        target_snapshot_json: str,
+    ) -> dict[str, Any]:
+        if target_id not in self._artifacts:
+            raise KeyError(f"target {target_id!r} not found")
+        if annotation_id in self._annotations:
+            raise ValueError(f"annotation {annotation_id!r} already exists")
+        now = time.time()
+        ann = _FakeAnnotation(
+            annotation_id=annotation_id,
+            target_id=target_id,
+            target_label=target_label,
+            kind=kind,
+            body=body,
+            tags=list(tags),
+            author=author,
+            created_at=now,
+            updated_at=now,
+            target_snapshot_json=target_snapshot_json,
+        )
+        self._annotations[annotation_id] = ann
+        return _annotation_to_dict(ann)
+
+    def replace_summary_annotation(
+        self,
+        *,
+        annotation_id: str,
+        target_id: str,
+        target_label: str,
+        body: str,
+        tags: list[str],
+        author: str,
+        target_snapshot_json: str,
+    ) -> dict[str, Any]:
+        if target_id not in self._artifacts:
+            raise KeyError(f"target {target_id!r} not found")
+        now = time.time()
+        existing = self._annotations.get(annotation_id)
+        if existing is None:
+            ann = _FakeAnnotation(
+                annotation_id=annotation_id,
+                target_id=target_id,
+                target_label=target_label,
+                kind="summary",
+                body=body,
+                tags=list(tags),
+                author=author,
+                created_at=now,
+                updated_at=now,
+                target_snapshot_json=target_snapshot_json,
+            )
+            self._annotations[annotation_id] = ann
+            return _annotation_to_dict(ann)
+        existing.target_id = target_id
+        existing.target_label = target_label
+        existing.kind = "summary"
+        existing.body = body
+        existing.tags = list(tags)
+        existing.author = author
+        existing.target_snapshot_json = target_snapshot_json
+        existing.updated_at = now
+        return _annotation_to_dict(existing)
+
+    def delete_annotation(self, *, annotation_id: str) -> bool:
+        if annotation_id not in self._annotations:
+            return False
+        del self._annotations[annotation_id]
+        return True
+
+    def list_orphans(self, *, limit: int) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for ann in self._annotations.values():
+            if ann.target_id is None:
+                out.append(_annotation_to_dict(ann))
+                if len(out) >= limit:
+                    break
+        return out
+
+    def reattach_orphan(self, *, annotation_id: str, new_target_id: str) -> bool:
+        ann = self._annotations.get(annotation_id)
+        if ann is None or ann.target_id is not None:
+            return False
+        target = self._artifacts.get(new_target_id)
+        if target is None:
+            return False
+        ann.target_id = new_target_id
+        ann.target_label = target.label
+        ann.updated_at = time.time()
+        return True
+
+
+def _annotation_to_dict(ann: _FakeAnnotation) -> dict[str, Any]:
+    return {
+        "annotation_id": ann.annotation_id,
+        "target_id": ann.target_id,
+        "target_label": ann.target_label,
+        "kind": ann.kind,
+        "body": ann.body,
+        "tags": list(ann.tags),
+        "author": ann.author,
+        "created_at": ann.created_at,
+        "updated_at": ann.updated_at,
+        "target_snapshot_json": ann.target_snapshot_json,
+    }

--- a/packages/guru-graph/src/guru_graph/testing/fake_backend.py
+++ b/packages/guru-graph/src/guru_graph/testing/fake_backend.py
@@ -224,6 +224,8 @@ class FakeBackend:
 
     def delete_artifact_with_descendants(self, *, node_id: str) -> list[str]:
         """See :meth:`ArtifactOpsBackend.delete_artifact_with_descendants`."""
+        if node_id not in self._artifacts:
+            return []
         # BFS over CONTAINS edges starting from node_id.
         result: list[str] = [node_id]
         seen: set[str] = {node_id}

--- a/packages/guru-graph/src/guru_graph/versioning.py
+++ b/packages/guru-graph/src/guru_graph/versioning.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-PROTOCOL_VERSION = "1.0.0"
-SCHEMA_VERSION = 1
+PROTOCOL_VERSION = "1.1.0"
+SCHEMA_VERSION = 2
 
 PROTOCOL_HEADER = "X-Guru-Graph-Protocol"
 

--- a/packages/guru-graph/tests/conftest.py
+++ b/packages/guru-graph/tests/conftest.py
@@ -48,12 +48,19 @@ def real_neo4j_backend(tmp_path: Path):
     # Connect-only mode shares DB state across tests — wipe before each.
     if external_uri is not None:
         backend.execute("MATCH (n) DETACH DELETE n", {})
-        for stmt in (
-            "DROP CONSTRAINT kb_name_unique IF EXISTS",
-            "DROP INDEX kb_updated_at IF EXISTS",
-        ):
+        constraints = backend.execute("SHOW CONSTRAINTS YIELD name RETURN name", {})
+        for row in constraints.rows:
             with contextlib.suppress(Exception):
-                backend.execute(stmt, {})
+                backend.execute(f"DROP CONSTRAINT `{row[0]}` IF EXISTS", {})
+        # `type <> 'LOOKUP'` filters out Neo4j's built-in lookup indexes
+        # (`node_label_lookup_index`, `relationship_type_lookup_index`) which
+        # can't be dropped.
+        indexes = backend.execute(
+            "SHOW INDEXES YIELD name, type WHERE type <> 'LOOKUP' RETURN name", {}
+        )
+        for row in indexes.rows:
+            with contextlib.suppress(Exception):
+                backend.execute(f"DROP INDEX `{row[0]}` IF EXISTS", {})
         # Reset cached schema_version since we just wiped _Meta.
         backend._schema_version = 0
     try:

--- a/packages/guru-graph/tests/test_fake_backend_artifacts.py
+++ b/packages/guru-graph/tests/test_fake_backend_artifacts.py
@@ -243,3 +243,7 @@ def test_get_document_snapshot_and_set_document_snapshot_roundtrip(backend: Fake
     snap = backend.get_document_snapshot(doc_id="doc")
     snap.append("mut")
     assert backend.get_document_snapshot(doc_id="doc") == ["a", "b", "c"]
+
+
+def test_delete_artifact_with_descendants_returns_empty_for_missing_node(backend: FakeBackend):
+    assert backend.delete_artifact_with_descendants(node_id="kb::ghost") == []

--- a/packages/guru-graph/tests/test_fake_backend_artifacts.py
+++ b/packages/guru-graph/tests/test_fake_backend_artifacts.py
@@ -1,0 +1,245 @@
+"""Unit tests for artifact ops on FakeBackend (in-memory).
+
+These exercise the ArtifactOpsBackend protocol methods on FakeBackend
+without touching Neo4j. They cover:
+- Document/artifact upsert + get
+- CONTAINS edges + neighbor walks + subtree collection
+- RELATES edges + list/remove
+- Annotation lifecycle (create, list, delete, orphan, reattach, replace)
+- Snapshot round-trip
+- find_artifacts filters
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from guru_graph.testing import FakeBackend
+
+
+@pytest.fixture
+def backend() -> FakeBackend:
+    b = FakeBackend()
+    b.start()
+    yield b
+    b.stop()
+
+
+def test_upsert_document_and_get_artifact(backend: FakeBackend):
+    backend.upsert_document(
+        node_id="doc-1", label="Document", properties={"path": "/a.py", "kb_name": "alpha"}
+    )
+    got = backend.get_artifact(node_id="doc-1")
+    assert got == {
+        "id": "doc-1",
+        "label": "Document",
+        "properties": {"path": "/a.py", "kb_name": "alpha"},
+    }
+
+
+def test_upsert_artifact_and_contains_edge_and_list_neighbors(backend: FakeBackend):
+    backend.upsert_document(node_id="doc", label="Document", properties={})
+    backend.upsert_artifact(node_id="fn", label="Function", properties={"name": "f"})
+    backend.create_contains_edge(from_id="doc", to_id="fn")
+    neighbors = backend.list_neighbors(
+        node_id="doc",
+        direction="out",
+        rel_type="CONTAINS",
+        kind=None,
+        depth=1,
+        limit=10,
+    )
+    assert [n["id"] for n in neighbors] == ["fn"]
+    assert neighbors[0]["rel_type"] == "CONTAINS"
+    assert neighbors[0]["label"] == "Function"
+
+
+def test_delete_artifact_with_descendants_returns_full_subtree(backend: FakeBackend):
+    backend.upsert_document(node_id="grand", label="Document", properties={})
+    backend.upsert_artifact(node_id="parent", label="Class", properties={})
+    backend.upsert_artifact(node_id="child", label="Method", properties={})
+    backend.create_contains_edge(from_id="grand", to_id="parent")
+    backend.create_contains_edge(from_id="parent", to_id="child")
+    ids = backend.delete_artifact_with_descendants(node_id="grand")
+    assert set(ids) == {"grand", "parent", "child"}
+
+
+def test_delete_artifact_removes_connected_edges(backend: FakeBackend):
+    backend.upsert_artifact(node_id="a", label="Class", properties={})
+    backend.upsert_artifact(node_id="b", label="Function", properties={})
+    backend.create_contains_edge(from_id="a", to_id="b")
+    backend.delete_artifact(node_id="a")
+    assert backend.get_artifact(node_id="a") is None
+    # Edge referencing deleted id must be gone.
+    assert (
+        backend.list_neighbors(
+            node_id="b", direction="in", rel_type="CONTAINS", kind=None, depth=1, limit=10
+        )
+        == []
+    )
+
+
+def test_create_and_list_annotation(backend: FakeBackend):
+    backend.upsert_artifact(node_id="fn", label="Function", properties={})
+    backend.create_annotation(
+        annotation_id="ann-1",
+        target_id="fn",
+        target_label="Function",
+        kind="note",
+        body="hello",
+        tags=["x"],
+        author="me",
+        target_snapshot_json="{}",
+    )
+    anns = backend.list_annotations_for(node_id="fn")
+    assert len(anns) == 1
+    assert anns[0]["annotation_id"] == "ann-1"
+    assert anns[0]["body"] == "hello"
+    assert anns[0]["tags"] == ["x"]
+
+
+def test_delete_annotation_returns_true_then_false(backend: FakeBackend):
+    backend.upsert_artifact(node_id="fn", label="Function", properties={})
+    backend.create_annotation(
+        annotation_id="ann-1",
+        target_id="fn",
+        target_label="Function",
+        kind="note",
+        body="b",
+        tags=[],
+        author="me",
+        target_snapshot_json="{}",
+    )
+    assert backend.delete_annotation(annotation_id="ann-1") is True
+    assert backend.delete_annotation(annotation_id="ann-1") is False
+
+
+def test_orphan_annotations_for_preserves_annotation_and_unsets_target(backend: FakeBackend):
+    backend.upsert_artifact(node_id="fn", label="Function", properties={})
+    backend.create_annotation(
+        annotation_id="ann-1",
+        target_id="fn",
+        target_label="Function",
+        kind="note",
+        body="b",
+        tags=[],
+        author="me",
+        target_snapshot_json="{}",
+    )
+    backend.orphan_annotations_for(node_ids=["fn"])
+    assert backend.list_annotations_for(node_id="fn") == []
+    orphans = backend.list_orphans(limit=10)
+    assert len(orphans) == 1
+    assert orphans[0]["annotation_id"] == "ann-1"
+    assert orphans[0]["target_id"] is None
+
+
+def test_list_orphans_skips_attached_annotations(backend: FakeBackend):
+    backend.upsert_artifact(node_id="fn", label="Function", properties={})
+    backend.create_annotation(
+        annotation_id="ann-attached",
+        target_id="fn",
+        target_label="Function",
+        kind="note",
+        body="b",
+        tags=[],
+        author="me",
+        target_snapshot_json="{}",
+    )
+    assert backend.list_orphans(limit=10) == []
+
+
+def test_reattach_orphan_sets_new_target(backend: FakeBackend):
+    backend.upsert_artifact(node_id="fn-old", label="Function", properties={})
+    backend.upsert_artifact(node_id="fn-new", label="Function", properties={})
+    backend.create_annotation(
+        annotation_id="ann",
+        target_id="fn-old",
+        target_label="Function",
+        kind="note",
+        body="b",
+        tags=[],
+        author="me",
+        target_snapshot_json="{}",
+    )
+    backend.orphan_annotations_for(node_ids=["fn-old"])
+    assert backend.reattach_orphan(annotation_id="ann", new_target_id="fn-new") is True
+    assert backend.list_annotations_for(node_id="fn-new")[0]["annotation_id"] == "ann"
+    # Re-attaching an already-attached annotation is not allowed.
+    assert backend.reattach_orphan(annotation_id="ann", new_target_id="fn-old") is False
+
+
+def test_replace_summary_annotation_updates_in_place(backend: FakeBackend):
+    backend.upsert_artifact(node_id="fn", label="Function", properties={})
+    backend.replace_summary_annotation(
+        annotation_id="sum-1",
+        target_id="fn",
+        target_label="Function",
+        body="v1",
+        tags=[],
+        author="me",
+        target_snapshot_json="{}",
+    )
+    backend.replace_summary_annotation(
+        annotation_id="sum-1",
+        target_id="fn",
+        target_label="Function",
+        body="v2",
+        tags=["latest"],
+        author="me",
+        target_snapshot_json="{}",
+    )
+    anns = backend.list_annotations_for(node_id="fn")
+    assert len(anns) == 1
+    assert anns[0]["body"] == "v2"
+    assert anns[0]["tags"] == ["latest"]
+    assert anns[0]["kind"] == "summary"
+
+
+def test_relates_edge_create_and_delete_and_list_relates_for(backend: FakeBackend):
+    backend.upsert_artifact(node_id="a", label="Module", properties={})
+    backend.upsert_artifact(node_id="b", label="Module", properties={})
+    backend.create_relates_edge(from_id="a", to_id="b", kind="imports", properties={"via": "ast"})
+    out = backend.list_relates_for(node_id="a", direction="out")
+    assert len(out) == 1
+    assert out[0]["to_id"] == "b"
+    assert out[0]["kind"] == "imports"
+    assert out[0]["properties"] == {"via": "ast"}
+    assert backend.delete_relates_edge(from_id="a", to_id="b", kind="imports") is True
+    assert backend.list_relates_for(node_id="a", direction="out") == []
+
+
+def test_remove_outbound_relates_rooted_at_wipes_descendants_relates(backend: FakeBackend):
+    backend.upsert_document(node_id="doc", label="Document", properties={})
+    backend.upsert_artifact(node_id="child", label="Function", properties={})
+    backend.upsert_artifact(node_id="other", label="Function", properties={})
+    backend.create_contains_edge(from_id="doc", to_id="child")
+    backend.create_relates_edge(from_id="child", to_id="other", kind="calls", properties={})
+    backend.remove_outbound_relates_rooted_at(doc_id="doc")
+    assert backend.list_relates_for(node_id="child", direction="out") == []
+
+
+def test_find_artifacts_filters_by_label_and_kb_name(backend: FakeBackend):
+    backend.upsert_artifact(node_id="c1", label="Class", properties={"kb_name": "alpha"})
+    backend.upsert_artifact(node_id="c2", label="Class", properties={"kb_name": "beta"})
+    backend.upsert_artifact(node_id="f1", label="Function", properties={"kb_name": "alpha"})
+    alpha_classes = backend.find_artifacts(
+        name=None,
+        qualname_prefix=None,
+        label="Class",
+        tag=None,
+        kb_name="alpha",
+        limit=10,
+    )
+    assert [a["id"] for a in alpha_classes] == ["c1"]
+
+
+def test_get_document_snapshot_and_set_document_snapshot_roundtrip(backend: FakeBackend):
+    backend.upsert_document(node_id="doc", label="Document", properties={})
+    assert backend.get_document_snapshot(doc_id="doc") == []
+    backend.set_document_snapshot(doc_id="doc", node_ids=["a", "b", "c"])
+    assert backend.get_document_snapshot(doc_id="doc") == ["a", "b", "c"]
+    # Returned list is independent of internal storage.
+    snap = backend.get_document_snapshot(doc_id="doc")
+    snap.append("mut")
+    assert backend.get_document_snapshot(doc_id="doc") == ["a", "b", "c"]

--- a/packages/guru-graph/tests/test_ingest_service.py
+++ b/packages/guru-graph/tests/test_ingest_service.py
@@ -110,3 +110,20 @@ def test_delete_nonexistent_document_is_noop():
     backend.start()
     svc = IngestService(backend=backend)
     svc.delete_document("kb", "kb::ghost.md")  # no exception
+
+
+def test_submit_deduplicates_shared_descendants_between_roots():
+    """If two removed-roots share a CONTAINS descendant, victims list has no duplicates."""
+    backend = FakeBackend()
+    backend.start()
+    svc = IngestService(backend=backend)
+    # Initial: doc -> A -> shared; doc -> B -> shared (diamond via CONTAINS)
+    svc.submit("kb", _payload("kb::x.md", ["kb::x.md::A", "kb::x.md::B", "kb::x.md::shared"]))
+    backend.create_contains_edge(from_id="kb::x.md::A", to_id="kb::x.md::shared")
+    backend.create_contains_edge(from_id="kb::x.md::B", to_id="kb::x.md::shared")
+    # Now re-submit with A and B both gone (so 'shared' is a descendant of both roots being deleted).
+    svc.submit("kb", _payload("kb::x.md", []))
+    # All three should be gone.
+    assert backend.get_artifact(node_id="kb::x.md::A") is None
+    assert backend.get_artifact(node_id="kb::x.md::B") is None
+    assert backend.get_artifact(node_id="kb::x.md::shared") is None

--- a/packages/guru-graph/tests/test_ingest_service.py
+++ b/packages/guru-graph/tests/test_ingest_service.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from guru_core.graph_types import GraphEdgePayload, GraphNodePayload, ParseResultPayload
+from guru_graph.services.ingest_service import IngestService
+from guru_graph.testing.fake_backend import FakeBackend
+
+
+def _payload(doc_id: str, sub_ids: list[str]) -> ParseResultPayload:
+    doc = GraphNodePayload(
+        node_id=doc_id,
+        label="Document",
+        properties={"kb_name": "kb", "language": "markdown"},
+    )
+    nodes = [
+        GraphNodePayload(
+            node_id=i,
+            label="MarkdownSection",
+            properties={"kb_name": "kb"},
+        )
+        for i in sub_ids
+    ]
+    edges = [GraphEdgePayload(from_id=doc_id, to_id=i, rel_type="CONTAINS") for i in sub_ids]
+    return ParseResultPayload(chunks_count=len(sub_ids), document=doc, nodes=nodes, edges=edges)
+
+
+def test_submit_creates_document_and_subnodes():
+    backend = FakeBackend()
+    backend.start()
+    svc = IngestService(backend=backend)
+    svc.submit("kb", _payload("kb::x.md", ["kb::x.md::A", "kb::x.md::B"]))
+    assert backend.get_artifact(node_id="kb::x.md") is not None
+    assert backend.get_artifact(node_id="kb::x.md::A") is not None
+    assert backend.get_artifact(node_id="kb::x.md::B") is not None
+    # snapshot recorded
+    assert set(backend.get_document_snapshot(doc_id="kb::x.md")) == {
+        "kb::x.md::A",
+        "kb::x.md::B",
+    }
+
+
+def test_submit_removes_deleted_subnodes_on_rerun():
+    backend = FakeBackend()
+    backend.start()
+    svc = IngestService(backend=backend)
+    svc.submit("kb", _payload("kb::x.md", ["kb::x.md::A", "kb::x.md::B"]))
+    svc.submit("kb", _payload("kb::x.md", ["kb::x.md::A"]))  # B removed
+    assert backend.get_artifact(node_id="kb::x.md::A") is not None
+    assert backend.get_artifact(node_id="kb::x.md::B") is None
+
+
+def test_submit_idempotent_when_payload_unchanged():
+    backend = FakeBackend()
+    backend.start()
+    svc = IngestService(backend=backend)
+    p = _payload("kb::x.md", ["kb::x.md::A"])
+    svc.submit("kb", p)
+    svc.submit("kb", p)
+    assert backend.get_artifact(node_id="kb::x.md::A") is not None
+
+
+def test_submit_replaces_outbound_relates_rooted_at_document():
+    backend = FakeBackend()
+    backend.start()
+    # Set up: submit doc with one section, then create a RELATES edge from
+    # the section to some other artifact (simulating an imports link).
+    svc = IngestService(backend=backend)
+    svc.submit("kb", _payload("kb::x.md", ["kb::x.md::A"]))
+    backend.upsert_artifact(
+        node_id="kb::other.py::mod", label="Module", properties={"kb_name": "kb"}
+    )
+    backend.create_relates_edge(
+        from_id="kb::x.md::A",
+        to_id="kb::other.py::mod",
+        kind="references",
+        properties={},
+    )
+    assert len(backend.list_relates_for(node_id="kb::x.md::A", direction="out")) == 1
+
+    # Resubmit without the RELATES edge: the old RELATES must be wiped.
+    svc.submit("kb", _payload("kb::x.md", ["kb::x.md::A"]))
+    assert backend.list_relates_for(node_id="kb::x.md::A", direction="out") == []
+
+
+def test_delete_document_cascades_and_orphans_annotations():
+    backend = FakeBackend()
+    backend.start()
+    svc = IngestService(backend=backend)
+    svc.submit("kb", _payload("kb::x.md", ["kb::x.md::A"]))
+    backend.create_annotation(
+        annotation_id="ann-1",
+        target_id="kb::x.md::A",
+        target_label="MarkdownSection",
+        kind="gotcha",
+        body="beware",
+        tags=[],
+        author="agent:test",
+        target_snapshot_json='{"target_id":"kb::x.md::A","target_kind":"MarkdownSection"}',
+    )
+
+    svc.delete_document("kb", "kb::x.md")
+    assert backend.get_artifact(node_id="kb::x.md::A") is None
+    assert backend.get_artifact(node_id="kb::x.md") is None
+    orphans = backend.list_orphans(limit=10)
+    assert len(orphans) == 1
+    assert orphans[0]["annotation_id"] == "ann-1"
+
+
+def test_delete_nonexistent_document_is_noop():
+    backend = FakeBackend()
+    backend.start()
+    svc = IngestService(backend=backend)
+    svc.delete_document("kb", "kb::ghost.md")  # no exception

--- a/packages/guru-graph/tests/test_m0002_migration.py
+++ b/packages/guru-graph/tests/test_m0002_migration.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from guru_graph.migrations.m0002_artifact_schema import apply as apply_m0002
+from guru_graph.testing.fake_backend import FakeBackend
+from guru_graph.versioning import VersionNegotiationError
+
+
+def test_m0002_apply_runs_ddl_and_ensure_schema_bumps_version():
+    backend = FakeBackend(_schema_version=1)
+    backend.start()
+    apply_m0002(backend)  # DDL is a no-op for FakeBackend but must not raise
+    backend.ensure_schema(target_version=2)
+    assert backend.info().schema_version == 2
+
+
+def test_m0002_rerun_is_idempotent_on_fake():
+    backend = FakeBackend(_schema_version=2)
+    backend.start()
+    # Re-apply against a v2 fake is safe (IF NOT EXISTS Cypher;
+    # FakeBackend.execute is a stub).
+    apply_m0002(backend)
+    apply_m0002(backend)
+    backend.ensure_schema(target_version=2)
+    assert backend.info().schema_version == 2
+
+
+def test_ensure_schema_refuses_downgrade_v3_to_v2():
+    backend = FakeBackend(_schema_version=3)
+    backend.start()
+    with pytest.raises(VersionNegotiationError):
+        backend.ensure_schema(target_version=2)
+
+
+def test_m0002_is_registered_in_migrations():
+    from guru_graph.migrations import MIGRATIONS
+
+    versions = [v for v, _fn in MIGRATIONS]
+    assert versions == sorted(versions)
+    assert 2 in versions

--- a/packages/guru-graph/tests/test_m0002_real_neo4j.py
+++ b/packages/guru-graph/tests/test_m0002_real_neo4j.py
@@ -12,8 +12,33 @@ def test_m0002_applied_to_empty_neo4j(real_neo4j_backend):
 
     result = real_neo4j_backend.execute_read("SHOW CONSTRAINTS YIELD name RETURN name", {})
     names = {row[0] for row in result.rows}
-    assert "document_id_unique" in names
-    assert "annotation_id_unique" in names
+    expected = {
+        "document_id_unique",
+        "module_id_unique",
+        "class_id_unique",
+        "function_id_unique",
+        "method_id_unique",
+        "oas_spec_id_unique",
+        "oas_op_id_unique",
+        "oas_schema_id_unique",
+        "md_section_id_unique",
+        "annotation_id_unique",
+    }
+    assert expected <= names, f"missing constraints: {expected - names}"
+
+    idx_result = real_neo4j_backend.execute_read("SHOW INDEXES YIELD name RETURN name", {})
+    idx_names = {row[0] for row in idx_result.rows}
+    expected_indexes = {
+        "document_kb_name",
+        "document_language",
+        "annotation_kind",
+        "annotation_author",
+        "module_qualname",
+        "class_qualname",
+        "function_qualname",
+        "method_qualname",
+    }
+    assert expected_indexes <= idx_names, f"missing indexes: {expected_indexes - idx_names}"
 
 
 def test_m0002_is_idempotent_on_real_neo4j(real_neo4j_backend):

--- a/packages/guru-graph/tests/test_m0002_real_neo4j.py
+++ b/packages/guru-graph/tests/test_m0002_real_neo4j.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.real_neo4j
+
+
+def test_m0002_applied_to_empty_neo4j(real_neo4j_backend):
+    """ensure_schema(2) runs m0001 + m0002; verify new constraint is installed."""
+    real_neo4j_backend.ensure_schema(target_version=2)
+    assert real_neo4j_backend.info().schema_version == 2
+
+    result = real_neo4j_backend.execute_read("SHOW CONSTRAINTS YIELD name RETURN name", {})
+    names = {row[0] for row in result.rows}
+    assert "document_id_unique" in names
+    assert "annotation_id_unique" in names
+
+
+def test_m0002_is_idempotent_on_real_neo4j(real_neo4j_backend):
+    real_neo4j_backend.ensure_schema(target_version=2)
+    real_neo4j_backend.ensure_schema(target_version=2)  # second call is a no-op
+    assert real_neo4j_backend.info().schema_version == 2

--- a/packages/guru-graph/tests/test_routes_ingest.py
+++ b/packages/guru-graph/tests/test_routes_ingest.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from guru_graph.app import create_app
+from guru_graph.testing.fake_backend import FakeBackend
+
+
+def _body(doc_id: str, sub_ids: list[str]) -> dict:
+    return {
+        "chunks_count": len(sub_ids),
+        "document": {
+            "node_id": doc_id,
+            "label": "Document",
+            "properties": {"kb_name": "kb", "language": "markdown"},
+        },
+        "nodes": [
+            {
+                "node_id": i,
+                "label": "MarkdownSection",
+                "properties": {"kb_name": "kb", "breadcrumb": "X"},
+            }
+            for i in sub_ids
+        ],
+        "edges": [
+            {
+                "from_id": doc_id,
+                "to_id": i,
+                "rel_type": "CONTAINS",
+                "kind": None,
+                "properties": {},
+            }
+            for i in sub_ids
+        ],
+    }
+
+
+def test_submit_parse_result_returns_204_and_creates_nodes():
+    backend = FakeBackend()
+    backend.start()
+    app = create_app(backend=backend)
+    client = TestClient(app)
+
+    r = client.post(
+        "/ingest/parse-result?kb_name=kb",
+        json=_body("kb::x.md", ["kb::x.md::Title"]),
+    )
+    assert r.status_code == 204
+    assert backend.get_artifact(node_id="kb::x.md") is not None
+    assert backend.get_artifact(node_id="kb::x.md::Title") is not None
+
+
+def test_delete_document_returns_204_and_removes_subtree():
+    backend = FakeBackend()
+    backend.start()
+    app = create_app(backend=backend)
+    client = TestClient(app)
+
+    client.post(
+        "/ingest/parse-result?kb_name=kb",
+        json=_body("kb::x.md", ["kb::x.md::A"]),
+    )
+    r = client.delete("/ingest/documents/kb::x.md?kb_name=kb")
+    assert r.status_code == 204
+    assert backend.get_artifact(node_id="kb::x.md") is None
+    assert backend.get_artifact(node_id="kb::x.md::A") is None
+
+
+def test_submit_parse_result_rejects_invalid_payload():
+    """Pydantic should reject a RELATES edge without kind."""
+    backend = FakeBackend()
+    backend.start()
+    app = create_app(backend=backend)
+    client = TestClient(app)
+
+    bad = _body("kb::x.md", ["kb::x.md::A"])
+    bad["edges"].append(
+        {
+            "from_id": "kb::x.md::A",
+            "to_id": "kb::other",
+            "rel_type": "RELATES",
+            "kind": None,  # RELATES requires kind; validator must reject
+            "properties": {},
+        }
+    )
+    r = client.post("/ingest/parse-result?kb_name=kb", json=bad)
+    assert r.status_code == 422  # FastAPI Pydantic validation

--- a/packages/guru-server/src/guru_server/app.py
+++ b/packages/guru-server/src/guru_server/app.py
@@ -161,6 +161,11 @@ def create_app(
     parser_registry.register(MarkdownParser())
     app.state.parser_registry = parser_registry
 
+    # Build graph client before BackgroundIndexer so it can be passed in.
+    graph_enabled = bool(app.state.config.graph and app.state.config.graph.enabled)
+    app.state.graph_enabled = graph_enabled
+    app.state.graph_client = build_graph_client_if_enabled(graph_enabled=graph_enabled)
+
     # Create indexer if we have all dependencies
     if store is not None and embedder is not None and app.state.manifest is not None:
         app.state.indexer = BackgroundIndexer(
@@ -172,13 +177,10 @@ def create_app(
             kb_name=app.state.project_name,
             embed_cache=embed_cache,
             parser_registry=parser_registry,
+            graph_client=app.state.graph_client,
         )
     else:
         app.state.indexer = None
-
-    graph_enabled = bool(app.state.config.graph and app.state.config.graph.enabled)
-    app.state.graph_enabled = graph_enabled
-    app.state.graph_client = build_graph_client_if_enabled(graph_enabled=graph_enabled)
 
     app.include_router(api_router)
     return app

--- a/packages/guru-server/src/guru_server/graph_integration.py
+++ b/packages/guru-server/src/guru_server/graph_integration.py
@@ -12,7 +12,8 @@ from typing import Any
 
 from guru_core.graph_client import GraphClient
 from guru_core.graph_errors import GraphUnavailable
-from guru_core.graph_types import KbUpsert
+from guru_core.graph_types import GraphEdgePayload, GraphNodePayload, KbUpsert, ParseResultPayload
+from guru_server.ingestion.base import ParseResult
 
 logger = logging.getLogger(__name__)
 
@@ -67,3 +68,35 @@ def build_graph_client_if_enabled(*, graph_enabled: bool) -> GraphClient | None:
     if not graph_enabled:
         return None
     return GraphClient(socket_path=None, auto_start=True)
+
+
+def parse_result_to_payload(pr: ParseResult) -> ParseResultPayload:
+    """Convert a parser's internal ParseResult into the Pydantic wire payload.
+
+    The server-side dataclasses (`GraphNode`, `GraphEdge`, `ParseResult`)
+    live in `guru_server.ingestion.base` — parsers should not depend on
+    Pydantic. This helper is the single conversion point to the wire schema
+    consumed by `/ingest/parse-result`.
+    """
+    return ParseResultPayload(
+        chunks_count=len(pr.chunks),
+        document=GraphNodePayload(
+            node_id=pr.document.node_id,
+            label=pr.document.label,
+            properties=pr.document.properties,
+        ),
+        nodes=[
+            GraphNodePayload(node_id=n.node_id, label=n.label, properties=n.properties)
+            for n in pr.nodes
+        ],
+        edges=[
+            GraphEdgePayload(
+                from_id=e.from_id,
+                to_id=e.to_id,
+                rel_type=e.rel_type,
+                kind=e.kind,
+                properties=e.properties,
+            )
+            for e in pr.edges
+        ],
+    )

--- a/packages/guru-server/src/guru_server/indexer.py
+++ b/packages/guru-server/src/guru_server/indexer.py
@@ -8,8 +8,10 @@ from pathlib import Path
 
 import numpy as np
 
+from guru_core.graph_client import GraphClient
 from guru_core.types import GuruConfig, Rule
 from guru_server.embed_cache import EmbeddingCache
+from guru_server.graph_integration import graph_or_skip, parse_result_to_payload
 from guru_server.ingestion.markdown import MarkdownParser
 from guru_server.ingestion.registry import ParserRegistry
 from guru_server.jobs import Job
@@ -63,6 +65,7 @@ class BackgroundIndexer:
         kb_name: str,
         embed_cache: EmbeddingCache | None = None,
         parser_registry: ParserRegistry | None = None,
+        graph_client: GraphClient | None = None,
     ) -> None:
         self._store = store
         self._manifest = manifest
@@ -72,6 +75,7 @@ class BackgroundIndexer:
         self._registry = parser_registry or _default_registry()
         self._cache = embed_cache
         self._kb_name = kb_name
+        self._graph_client = graph_client
 
     async def run(self, job: Job) -> None:
         """Execute a two-phase indexing job."""
@@ -125,6 +129,14 @@ class BackgroundIndexer:
                 job.files_deleted = len(to_delete)
                 for rel_path in to_delete:
                     logger.info("[job %s] Deleted %s (removed from disk)", short_id, rel_path)
+                    if self._graph_client is not None:
+                        doc_id = f"{self._kb_name}::{rel_path}"
+                        await graph_or_skip(
+                            self._graph_client.delete_document_in_graph(
+                                kb_name=self._kb_name, doc_id=doc_id
+                            ),
+                            feature="ingest_delete",
+                        )
 
             job.status = "completed"
             job.phase = None
@@ -248,6 +260,16 @@ class BackgroundIndexer:
                 mtime=current_mtime,
                 chunk_count=0,
             )
+            # Treat an empty-chunks parse as a deletion for the graph — the document
+            # lost all its sections; the graph should reflect that.
+            if self._graph_client is not None:
+                doc_id = f"{self._kb_name}::{rel_path}"
+                await graph_or_skip(
+                    self._graph_client.delete_document_in_graph(
+                        kb_name=self._kb_name, doc_id=doc_id
+                    ),
+                    feature="ingest_delete",
+                )
             job.files_processed += 1
             return
 
@@ -269,6 +291,12 @@ class BackgroundIndexer:
 
         job.files_processed += 1
         job.chunks_created += len(chunks)
+        if self._graph_client is not None:
+            payload = parse_result_to_payload(parse_result)
+            await graph_or_skip(
+                self._graph_client.submit_parse_result(kb_name=self._kb_name, payload=payload),
+                feature="ingest_artifacts",
+            )
         logger.info("[job %s] Indexed %s (%d chunks)", short_id, rel_path, len(chunks))
 
     async def _embed_with_cache(

--- a/packages/guru-server/src/guru_server/indexer.py
+++ b/packages/guru-server/src/guru_server/indexer.py
@@ -245,7 +245,7 @@ class BackgroundIndexer:
 
         parser = self._registry.dispatch(file_path)
         assert parser is not None, f"no parser for {file_path} — discovery should have filtered it"
-        parse_result = parser.parse(file_path, rule, kb_name=self._kb_name)
+        parse_result = parser.parse(file_path, rule, kb_name=self._kb_name, rel_path=rel_path)
         chunks = parse_result.chunks
         # parse_result.document/nodes/edges are captured but discarded in PR-1 —
         # PR-2 wires them into graph ingestion via graph_or_skip.

--- a/packages/guru-server/src/guru_server/ingestion/base.py
+++ b/packages/guru-server/src/guru_server/ingestion/base.py
@@ -38,7 +38,9 @@ class DocumentParser(ABC):
     def supports(self, file_path: Path) -> bool: ...
 
     @abstractmethod
-    def parse(self, file_path: Path, rule: Rule, *, kb_name: str) -> ParseResult: ...
+    def parse(
+        self, file_path: Path, rule: Rule, *, kb_name: str, rel_path: str
+    ) -> ParseResult: ...
 
 
 @dataclass

--- a/packages/guru-server/src/guru_server/ingestion/markdown.py
+++ b/packages/guru-server/src/guru_server/ingestion/markdown.py
@@ -53,7 +53,7 @@ class MarkdownParser(DocumentParser):
     def supports(self, file_path: Path) -> bool:
         return file_path.suffix.lower() in (".md", ".markdown")
 
-    def parse(self, file_path: Path, rule: Rule, *, kb_name: str) -> ParseResult:
+    def parse(self, file_path: Path, rule: Rule, *, kb_name: str, rel_path: str) -> ParseResult:
         raw = file_path.read_text(encoding="utf-8")
         post = frontmatter.loads(raw)
         fm = _sanitize_frontmatter(dict(post.metadata))
@@ -65,13 +65,13 @@ class MarkdownParser(DocumentParser):
         if rule.chunking is not None:
             split_level = rule.chunking.split_level
 
-        document_id = f"{kb_name}::{file_path.as_posix()}"
+        document_id = f"{kb_name}::{rel_path}"
         document_node = GraphNode(
             node_id=document_id,
             label="Document",
             properties={
                 "kb_name": kb_name,
-                "relative_path": file_path.as_posix(),
+                "relative_path": rel_path,
                 "absolute_path": str(file_path),
                 "language": "markdown",
                 "file_type": "doc",

--- a/packages/guru-server/tests/test_indexer.py
+++ b/packages/guru-server/tests/test_indexer.py
@@ -227,7 +227,7 @@ async def test_cache_hit_skips_embedder(
     parser = MarkdownParser()
     rule = Rule(rule_name="docs", match=MatchConfig(glob="docs/**/*.md"))
     for md in (project_dir / "docs").glob("*.md"):
-        chunks = parser.parse(md, rule, kb_name="test").chunks
+        chunks = parser.parse(md, rule, kb_name="test", rel_path=md.name).chunks
         for chunk in chunks:
             key = (hashlib.sha256(chunk.content.encode("utf-8")).digest(), "nomic-embed-text")
             embed_cache.put_many([(key, np.array([0.1] * 768, dtype=np.float32))])
@@ -305,7 +305,9 @@ async def test_cache_mixed_hit_miss_preserves_order(
     rule = Rule(rule_name="docs", match=MatchConfig(glob="docs/**/*.md"))
     hit_vector = np.array([0.42] * 768, dtype=np.float32)
     all_md_files = sorted((project_dir / "docs").glob("*.md"))
-    first_file_chunks = parser.parse(all_md_files[0], rule, kb_name="test").chunks
+    first_file_chunks = parser.parse(
+        all_md_files[0], rule, kb_name="test", rel_path=all_md_files[0].name
+    ).chunks
     assert first_file_chunks, "Test fixture must produce at least one chunk"
     first_chunk_text = first_file_chunks[0].content
     key = (hashlib.sha256(first_chunk_text.encode("utf-8")).digest(), "nomic-embed-text")

--- a/packages/guru-server/tests/test_indexer_graph_integration.py
+++ b/packages/guru-server/tests/test_indexer_graph_integration.py
@@ -1,0 +1,72 @@
+"""Tests for indexer <-> graph integration helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from guru_core.graph_errors import GraphUnavailable
+from guru_server.graph_integration import graph_or_skip, parse_result_to_payload
+from guru_server.ingestion.base import GraphEdge, GraphNode, ParseResult
+
+
+def test_parse_result_to_payload_roundtrip_document_only():
+    doc = GraphNode(
+        node_id="kb::x.md",
+        label="Document",
+        properties={"language": "markdown", "kb_name": "kb"},
+    )
+    pr = ParseResult(chunks=[], document=doc, nodes=[], edges=[])
+    payload = parse_result_to_payload(pr)
+    assert payload.chunks_count == 0
+    assert payload.document.node_id == "kb::x.md"
+    assert payload.document.label == "Document"
+    assert payload.document.properties == {"language": "markdown", "kb_name": "kb"}
+    assert payload.nodes == []
+    assert payload.edges == []
+
+
+def test_parse_result_to_payload_with_nodes_and_contains_edges():
+    doc = GraphNode(node_id="kb::x.md", label="Document", properties={})
+    n1 = GraphNode(node_id="kb::x.md::A", label="MarkdownSection", properties={"title": "A"})
+    n2 = GraphNode(node_id="kb::x.md::B", label="MarkdownSection", properties={"title": "B"})
+    e1 = GraphEdge(from_id="kb::x.md", to_id="kb::x.md::A", rel_type="CONTAINS")
+    e2 = GraphEdge(from_id="kb::x.md::A", to_id="kb::x.md::B", rel_type="CONTAINS")
+    pr = ParseResult(chunks=[], document=doc, nodes=[n1, n2], edges=[e1, e2])
+    payload = parse_result_to_payload(pr)
+    assert len(payload.nodes) == 2
+    assert len(payload.edges) == 2
+    assert payload.edges[0].rel_type == "CONTAINS"
+    assert payload.edges[0].kind is None
+
+
+def test_parse_result_to_payload_preserves_relates_kind():
+    doc = GraphNode(node_id="kb::x.md", label="Document", properties={})
+    e = GraphEdge(
+        from_id="kb::x.md",
+        to_id="kb::other",
+        rel_type="RELATES",
+        kind="references",
+        properties={"snippet": "see other"},
+    )
+    pr = ParseResult(chunks=[], document=doc, nodes=[], edges=[e])
+    payload = parse_result_to_payload(pr)
+    assert payload.edges[0].kind == "references"
+    assert payload.edges[0].properties == {"snippet": "see other"}
+
+
+@pytest.mark.asyncio
+async def test_graph_or_skip_swallows_graph_unavailable():
+    async def _boom():
+        raise GraphUnavailable("simulated")
+
+    result = await graph_or_skip(_boom(), feature="test_2_7")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_graph_or_skip_returns_value_on_success():
+    async def _ok():
+        return "hello"
+
+    result = await graph_or_skip(_ok(), feature="test_2_7_ok")
+    assert result == "hello"

--- a/packages/guru-server/tests/test_ingestion.py
+++ b/packages/guru-server/tests/test_ingestion.py
@@ -103,7 +103,7 @@ def parser() -> MarkdownParser:
 
 @pytest.fixture
 def chunks(parser: MarkdownParser, md_file: Path, rule: Rule) -> list[Chunk]:
-    return parser.parse(md_file, rule, kb_name="test").chunks
+    return parser.parse(md_file, rule, kb_name="test", rel_path=md_file.name).chunks
 
 
 # --- Chunk dataclass ---
@@ -269,7 +269,7 @@ def test_content_type_default_is_text(chunks: list[Chunk]):
 def test_content_type_code(parser: MarkdownParser, tmp_path: Path, rule: Rule):
     p = tmp_path / "code.md"
     p.write_text(SAMPLE_MD_CODE, encoding="utf-8")
-    result = parser.parse(p, rule, kb_name="test").chunks
+    result = parser.parse(p, rule, kb_name="test", rel_path=p.name).chunks
     code_chunks = [c for c in result if "```" in c.content]
     assert code_chunks, "Expected at least one chunk with a code block"
     for c in code_chunks:
@@ -279,7 +279,7 @@ def test_content_type_code(parser: MarkdownParser, tmp_path: Path, rule: Rule):
 def test_content_type_table(parser: MarkdownParser, tmp_path: Path, rule: Rule):
     p = tmp_path / "table.md"
     p.write_text(SAMPLE_MD_TABLE, encoding="utf-8")
-    result = parser.parse(p, rule, kb_name="test").chunks
+    result = parser.parse(p, rule, kb_name="test", rel_path=p.name).chunks
     table_chunks = [c for c in result if "|" in c.content]
     assert table_chunks, "Expected at least one chunk with a table"
     for c in table_chunks:
@@ -289,7 +289,7 @@ def test_content_type_table(parser: MarkdownParser, tmp_path: Path, rule: Rule):
 def test_content_type_mixed(parser: MarkdownParser, tmp_path: Path, rule: Rule):
     p = tmp_path / "mixed.md"
     p.write_text(SAMPLE_MD_MIXED, encoding="utf-8")
-    result = parser.parse(p, rule, kb_name="test").chunks
+    result = parser.parse(p, rule, kb_name="test", rel_path=p.name).chunks
     mixed_chunks = [c for c in result if "```" in c.content and "|" in c.content]
     assert mixed_chunks, "Expected at least one chunk with both code and table"
     for c in mixed_chunks:
@@ -302,7 +302,7 @@ def test_content_type_mixed(parser: MarkdownParser, tmp_path: Path, rule: Rule):
 def test_parent_chunk_id_set_on_h3_chunks(parser: MarkdownParser, tmp_path: Path, rule: Rule):
     p = tmp_path / "deep.md"
     p.write_text(SAMPLE_MD_WITH_H3, encoding="utf-8")
-    result = parser.parse(p, rule, kb_name="test").chunks
+    result = parser.parse(p, rule, kb_name="test", rel_path=p.name).chunks
     l3_chunks = [c for c in result if c.chunk_level == 3]
     l2_chunks = [c for c in result if c.chunk_level == 2]
     assert l3_chunks, "Expected level-3 chunks from h3 headers"
@@ -320,7 +320,7 @@ def test_parent_chunk_id_set_on_h3_chunks(parser: MarkdownParser, tmp_path: Path
 def test_l2_chunks_have_no_parent(parser: MarkdownParser, tmp_path: Path, rule: Rule):
     p = tmp_path / "deep.md"
     p.write_text(SAMPLE_MD_WITH_H3, encoding="utf-8")
-    result = parser.parse(p, rule, kb_name="test").chunks
+    result = parser.parse(p, rule, kb_name="test", rel_path=p.name).chunks
     l2_chunks = [c for c in result if c.chunk_level == 2]
     for c in l2_chunks:
         assert c.parent_chunk_id is None, (
@@ -340,7 +340,7 @@ def test_split_level_h2_merges_h3_into_parent(parser: MarkdownParser, tmp_path: 
     )
     p = tmp_path / "deep.md"
     p.write_text(SAMPLE_MD_WITH_H3, encoding="utf-8")
-    result = parser.parse(p, rule_h2, kb_name="test").chunks
+    result = parser.parse(p, rule_h2, kb_name="test", rel_path=p.name).chunks
     l3_chunks = [c for c in result if c.chunk_level == 3]
     assert l3_chunks == [], (
         f"Expected no level-3 chunks when split_level='h2', but found: {[c.header_breadcrumb for c in l3_chunks]}"
@@ -362,7 +362,7 @@ def test_split_level_h3_keeps_all_levels(parser: MarkdownParser, tmp_path: Path)
     )
     p = tmp_path / "deep.md"
     p.write_text(SAMPLE_MD_WITH_H3, encoding="utf-8")
-    result = parser.parse(p, rule_h3, kb_name="test").chunks
+    result = parser.parse(p, rule_h3, kb_name="test", rel_path=p.name).chunks
     l3_chunks = [c for c in result if c.chunk_level == 3]
     assert l3_chunks, "Expected level-3 chunks when split_level='h3'"
 
@@ -402,7 +402,7 @@ def test_frontmatter_with_dates_is_json_serializable(
 
     p = tmp_path / "cr_001.md"
     p.write_text(SAMPLE_MD_WITH_DATE, encoding="utf-8")
-    chunks = parser.parse(p, rule, kb_name="test").chunks
+    chunks = parser.parse(p, rule, kb_name="test", rel_path=p.name).chunks
     assert chunks, "Expected at least one chunk"
     for chunk in chunks:
         # This must not raise TypeError

--- a/packages/guru-server/tests/unit/test_markdown_parser.py
+++ b/packages/guru-server/tests/unit/test_markdown_parser.py
@@ -18,9 +18,9 @@ def md_tmp(tmp_path: Path) -> Path:
 def test_markdown_parser_returns_parse_result(md_tmp: Path):
     parser = MarkdownParser()
     rule = Rule(ruleName="default", match=MatchConfig(glob="**/*.md"))
-    result = parser.parse(md_tmp, rule, kb_name="alpha")
+    result = parser.parse(md_tmp, rule, kb_name="alpha", rel_path=md_tmp.name)
     assert result.document.label == "Document"
-    assert result.document.node_id.startswith("alpha::")
+    assert result.document.node_id == f"alpha::{md_tmp.name}"
     assert result.document.properties["language"] == "markdown"
     assert result.document.properties["file_type"] == "doc"
     assert len(result.chunks) >= 2
@@ -29,7 +29,7 @@ def test_markdown_parser_returns_parse_result(md_tmp: Path):
 def test_markdown_parser_emits_section_nodes(md_tmp: Path):
     parser = MarkdownParser()
     rule = Rule(ruleName="default", match=MatchConfig(glob="**/*.md"))
-    result = parser.parse(md_tmp, rule, kb_name="alpha")
+    result = parser.parse(md_tmp, rule, kb_name="alpha", rel_path=md_tmp.name)
     section_nodes = [n for n in result.nodes if n.label == "MarkdownSection"]
     assert len(section_nodes) >= 2
 
@@ -37,7 +37,7 @@ def test_markdown_parser_emits_section_nodes(md_tmp: Path):
 def test_markdown_parser_emits_contains_edges(md_tmp: Path):
     parser = MarkdownParser()
     rule = Rule(ruleName="default", match=MatchConfig(glob="**/*.md"))
-    result = parser.parse(md_tmp, rule, kb_name="alpha")
+    result = parser.parse(md_tmp, rule, kb_name="alpha", rel_path=md_tmp.name)
     contains = [e for e in result.edges if e.rel_type == "CONTAINS"]
     assert any(e.from_id == result.document.node_id for e in contains)
 
@@ -45,7 +45,7 @@ def test_markdown_parser_emits_contains_edges(md_tmp: Path):
 def test_markdown_parser_chunks_carry_pointer_metadata(md_tmp: Path):
     parser = MarkdownParser()
     rule = Rule(ruleName="default", match=MatchConfig(glob="**/*.md"))
-    result = parser.parse(md_tmp, rule, kb_name="alpha")
+    result = parser.parse(md_tmp, rule, kb_name="alpha", rel_path=md_tmp.name)
     for c in result.chunks:
         assert c.kind == "markdown_section"
         assert c.language == "markdown"
@@ -76,7 +76,7 @@ def test_markdown_parser_h2_merge_keeps_nodes_aligned_with_chunks(tmp_path: Path
         match=MatchConfig(glob="**/*.md"),
         chunking=ChunkingConfig(split_level="h2"),
     )
-    result = parser.parse(p, rule, kb_name="alpha")
+    result = parser.parse(p, rule, kb_name="alpha", rel_path=p.name)
 
     section_breadcrumbs = {
         sn.properties["breadcrumb"] for sn in result.nodes if sn.label == "MarkdownSection"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ dev = [
 target-version = "py313"
 line-length = 99
 src = ["packages/guru-core/src", "packages/guru-server/src", "packages/guru-mcp/src", "packages/guru-cli/src", "packages/guru-graph/src"]
+extend-exclude = ["tests/e2e/fixtures"]
+force-exclude = true
 
 [tool.ruff.lint]
 select = [

--- a/tests/e2e/features/artifact_indexing.feature
+++ b/tests/e2e/features/artifact_indexing.feature
@@ -1,0 +1,65 @@
+Feature: Artifact graph indexing for Python, OpenAPI, and Markdown
+
+  Background:
+    Given the "polyglot" fixture project is copied to a tmpdir
+
+  @real_neo4j
+  Scenario: Markdown index creates Document + MarkdownSection nodes
+    Given graph is enabled
+    When I run 'guru index'
+    Then (:Document {id: "polyglot::docs/guide.md"}) exists in the graph
+    And at least one (:MarkdownSection) node under docs/guide.md exists
+    And LanceDB contains chunks for docs/guide.md with kind="markdown_section"
+
+  @skip_until_pr7 @real_neo4j @real_ollama
+  Scenario: Fresh index populates LanceDB and graph in lockstep
+    Given graph is enabled
+    When I run 'guru index'
+    Then LanceDB contains chunks for every file, each with kind/language metadata
+    And every indexed file has a corresponding (:Document) node in the graph
+    And pkg.auth has a (:Module) node containing its classes and functions
+    And every (:Class) in pkg.services.user has its (:Method) children via :CONTAINS
+    And api/openapi.yaml has one (:OpenApiSpec) + N (:OpenApiOperation) + M (:OpenApiSchema)
+    And docs/guide.md has (:MarkdownSection) nodes matching its H2/H3 headings
+
+  @skip_until_pr7 @real_neo4j
+  Scenario: Parser emits structural imports and inheritance
+    When I run 'guru index'
+    Then (:Module "pkg.auth")-[:RELATES {kind:"imports"}]->(:Module "pkg.services.user") exists
+    And for every `class Derived(Base):`, (:Class)-[:RELATES {kind:"inherits_from"}]-> exists
+
+  @skip_until_pr7 @real_neo4j
+  Scenario: Re-indexing an unchanged file is a no-op in the graph
+    Given `guru index` has run once
+    When I record the (:Document) updated_at timestamps
+    And I run `guru index` again without modifying files
+    Then every (:Document).updated_at is unchanged
+    And no transactions were committed to Neo4j beyond reads
+
+  @skip_until_pr7 @real_neo4j
+  Scenario: Editing a file adds/removes artifacts via diff reconciliation
+    Given `guru index` has run once
+    When I add a new method `logout` to UserService in pkg.services.user
+    And I remove the method `deprecated_fn` from pkg.services.user
+    And I run `guru index`
+    Then (:Method "pkg.services.user.UserService.logout") exists
+    And (:Method "pkg.services.user.UserService.deprecated_fn") does not exist
+    And no other (:Method) node under UserService was touched
+
+  @skip_until_pr7 @real_neo4j
+  Scenario: Deleting a file cascades and creates orphans
+    Given an annotation was written on (:Function "pkg.auth.hash_password")
+    When the file src/pkg/auth.py is deleted
+    And I run `guru index`
+    Then (:Document "polyglot::src/pkg/auth.py") does not exist
+    And no (:Module "pkg.auth") exists
+    And the annotation is now an orphan (no outgoing :ANNOTATES edge)
+    And graph_orphans() returns it with target_snapshot_json pointing at "pkg.auth.hash_password"
+
+  @skip_until_pr7
+  Scenario: Extensible parser registration works without core change
+    Given a test parser "ProtobufParser" is registered at startup
+    And the fixture has a file api/schema.proto
+    When I run `guru index`
+    Then the ProtobufParser was dispatched for api/schema.proto
+    And the emitted (:Document) + custom labels are present in the graph

--- a/tests/e2e/features/environment.py
+++ b/tests/e2e/features/environment.py
@@ -567,6 +567,20 @@ def _trigger_and_wait_index(project_dir: Path, timeout: float = 30.0) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def before_scenario(context, scenario):
+    """Auto-skip scenarios that are specified but rely on later-PR machinery.
+
+    Scenarios tagged with `@skip_until_prN` document future behavior and are
+    intentionally under-implemented at this point in the plan. We mark them
+    skipped here so behave treats them as skipped rather than erroring on
+    undefined steps.
+    """
+    for tag in scenario.tags:
+        if tag.startswith("skip_until_"):
+            scenario.skip(f"pending: {tag}")
+            return
+
+
 def before_feature(context, feature):
     """Start a fresh server for each feature.
 
@@ -575,7 +589,41 @@ def before_feature(context, feature):
     - @gitignore_project → git-repo project with gitignored files
     - @federation → federation tests; no default server is started
     - (default) → standard project with mocked embedder
+
+    The artifact_indexing and graph_optional features use the polyglot fixture
+    and drive server startup from their own step definitions (via
+    `Given graph is enabled/disabled`), so we only set up the embedding cache
+    and @real_neo4j skip logic here.
     """
+    # artifact_indexing / graph_optional scenarios copy the polyglot fixture
+    # from a Background step and start their own server. We just need to
+    # isolate the embedding cache and auto-skip @real_neo4j when the env
+    # doesn't provide a Neo4j.
+    if "artifact_indexing" in feature.filename or "graph_optional" in feature.filename:
+        cache_fd, cache_name = tempfile.mkstemp(prefix="guru-test-cache-", suffix=".db")
+        os.close(cache_fd)
+        os.environ["GURU_EMBED_CACHE_PATH"] = cache_name
+        context._cache_path = cache_name
+        context._polyglot_managed = True
+
+        # Isolate graph daemon state — matches the graph_plugin hook so the
+        # @real_neo4j subset doesn't collide with other features' daemons.
+        context.graph_tmp = tempfile.mkdtemp(prefix="guru-graph-art-")
+        context.guru_tmp_cfg = tempfile.mkdtemp(prefix="guru-art-cfg-")
+        os.environ["XDG_CONFIG_HOME"] = context.guru_tmp_cfg
+        os.environ["XDG_DATA_HOME"] = os.path.join(context.graph_tmp, "data")
+        os.environ["XDG_STATE_HOME"] = os.path.join(context.graph_tmp, "state")
+        os.environ["XDG_RUNTIME_DIR"] = os.path.join(context.graph_tmp, "run")
+        os.environ["GURU_GRAPH_HOME"] = os.path.join(context.graph_tmp, "home")
+
+        if "real_neo4j" in feature.tags and os.environ.get("GURU_REAL_NEO4J") != "1":
+            feature.skip("GURU_REAL_NEO4J=1 not set")
+            return
+        for scenario in feature.scenarios:
+            if "real_neo4j" in scenario.tags and os.environ.get("GURU_REAL_NEO4J") != "1":
+                scenario.skip("GURU_REAL_NEO4J=1 not set")
+        return
+
     # Graph plugin scenarios are self-contained — they use GraphClient or a
     # FakeBackend directly rather than needing a default guru-server startup.
     # Skip the normal server-bootstrap path.
@@ -639,6 +687,63 @@ def before_feature(context, feature):
 
 def after_feature(context, feature):
     """Stop the server and clean up."""
+    if getattr(context, "_polyglot_managed", False):
+        import contextlib as _ctx
+        import os as _os
+        import shutil as _shutil
+
+        # Stop any guru-server the steps started.
+        if hasattr(context, "server") and context.server is not None:
+            context.server.should_exit = True
+        if hasattr(context, "server_thread") and context.server_thread is not None:
+            context.server_thread.join(timeout=5)
+
+        # Remove the per-feature project tmpdir (copied from fixtures/).
+        project_dir = getattr(context, "project_dir", None)
+        if project_dir is not None:
+            pid_path = project_dir / ".guru" / "guru.pid"
+            sock_path = project_dir / ".guru" / "guru.sock"
+            with _ctx.suppress(FileNotFoundError):
+                pid_path.unlink()
+            with _ctx.suppress(FileNotFoundError):
+                sock_path.unlink()
+            _shutil.rmtree(project_dir, ignore_errors=True)
+
+        polyglot_tmp_root = getattr(context, "_polyglot_tmp_root", None)
+        if polyglot_tmp_root is not None:
+            _shutil.rmtree(polyglot_tmp_root, ignore_errors=True)
+
+        # Kill any daemon we (or auto-start) spawned.
+        with _ctx.suppress(Exception):
+            from guru_graph.config import GraphPaths as _GP
+            from guru_graph.lifecycle import read_pid_file as _rpf
+
+            paths = _GP.default()
+            pid = _rpf(paths.pid_file)
+            if pid:
+                with _ctx.suppress(ProcessLookupError):
+                    _os.kill(pid, 15)
+
+        for attr in ("graph_tmp", "guru_tmp_cfg"):
+            d = getattr(context, attr, None)
+            if d:
+                _shutil.rmtree(d, ignore_errors=True)
+        for key in (
+            "GURU_GRAPH_HOME",
+            "XDG_DATA_HOME",
+            "XDG_STATE_HOME",
+            "XDG_RUNTIME_DIR",
+            "XDG_CONFIG_HOME",
+        ):
+            _os.environ.pop(key, None)
+
+        # Clean up the isolated embedding cache
+        cache_path = getattr(context, "_cache_path", None)
+        if cache_path and os.path.exists(cache_path):
+            os.unlink(cache_path)
+        os.environ.pop("GURU_EMBED_CACHE_PATH", None)
+        return
+
     if "graph_plugin" in feature.filename or "graph_cli_reads" in feature.filename:
         import contextlib as _ctx
         import os as _os

--- a/tests/e2e/features/graph_optional.feature
+++ b/tests/e2e/features/graph_optional.feature
@@ -1,0 +1,43 @@
+Feature: Graph is strictly optional — guru operates identically without it
+
+  Background:
+    Given the "polyglot" fixture project is copied to a tmpdir
+
+  Scenario: Full guru lifecycle with graph disabled
+    Given graph is disabled
+    When I run 'guru index'
+    Then the index command succeeds
+    And the server status reports graph_reachable = False
+    And the server status reports graph_enabled = False
+    And no guru-graph daemon was spawned
+
+  Scenario: Indexing with graph disabled does not attempt graph calls
+    Given graph is disabled
+    When I run 'guru index'
+    Then the index command succeeds
+    And the server's graph client is None
+
+  @skip_until_pr5
+  Scenario: Graph MCP tools return status, not error, when disabled
+    Given graph is disabled
+    When MCP calls graph_describe, graph_find, graph_orphans, graph_annotate
+    Then each returns {"status":"graph_disabled", ...}
+    And none raise exceptions
+
+  @skip_until_pr5
+  Scenario: CLI graph commands exit 0 when graph disabled
+    Given graph is disabled
+    When I run 'guru graph orphans'
+    Then exit code is 0
+    And stdout contains "graph is disabled"
+
+  @skip_until_pr3 @real_neo4j
+  Scenario: Daemon crash mid-indexing — guru-server completes; graph data is partial
+    Given graph is enabled and `guru index` is running
+    When I SIGKILL guru-graph after the 3rd file is indexed
+    Then `guru index` still completes
+    And LanceDB contains every chunk
+    And the graph contains what was submitted before the kill
+    And `guru status` reports graph_reachable=false afterwards
+    When I re-run `guru index` after daemon recovery
+    Then the graph catches up to match LanceDB exactly

--- a/tests/e2e/features/steps/artifact_steps.py
+++ b/tests/e2e/features/steps/artifact_steps.py
@@ -1,0 +1,305 @@
+"""Step definitions for artifact_indexing.feature and graph_optional.feature.
+
+The Markdown-only subset + graph_optional scenarios are fully implemented here.
+Python- and OpenAPI-dependent scenarios (tagged @skip_until_pr7 / @skip_until_pr8)
+are specified in the feature files but their steps live in later-PR step files.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from behave import given, then, when
+
+_FIXTURES_DIR = Path(__file__).resolve().parent.parent.parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _config_path(project_dir: Path) -> Path:
+    """Return the preferred local config path for a fixture project."""
+    for name in (".guru.json", "guru.json"):
+        path = project_dir / name
+        if path.exists():
+            return path
+    # Fall back to .guru.json (preferred dotfile) if none exist yet.
+    return project_dir / ".guru.json"
+
+
+def _load_config(project_dir: Path) -> dict:
+    path = _config_path(project_dir)
+    if path.exists():
+        return json.loads(path.read_text())
+    return {"version": 1}
+
+
+def _save_config(project_dir: Path, config: dict) -> None:
+    path = _config_path(project_dir)
+    path.write_text(json.dumps(config, indent=2) + "\n")
+
+
+def _set_graph_enabled(project_dir: Path, enabled: bool) -> None:
+    config = _load_config(project_dir)
+    config.setdefault("version", 1)
+    config["graph"] = {"enabled": enabled}
+    _save_config(project_dir, config)
+
+
+def _start_server_for_context(context) -> None:
+    """Start a guru-server for context.project_dir, shutting down any prior one."""
+    from environment import _make_fake_embedder, _start_server
+
+    # Ensure .guru/ and .guru/db exist (fixture comes without them).
+    guru_dir = context.project_dir / ".guru"
+    guru_dir.mkdir(exist_ok=True)
+    (guru_dir / "db").mkdir(exist_ok=True)
+
+    # Tear down any existing server bound to this project dir.
+    _stop_server_for_context(context)
+
+    if not getattr(context, "embedder", None):
+        context.embedder = _make_fake_embedder()
+    context.server, context.server_thread = _start_server(context.project_dir, context.embedder)
+
+
+def _stop_server_for_context(context) -> None:
+    server = getattr(context, "server", None)
+    thread = getattr(context, "server_thread", None)
+    if server is not None:
+        server.should_exit = True
+    if thread is not None:
+        thread.join(timeout=5)
+    context.server = None
+    context.server_thread = None
+
+    if getattr(context, "project_dir", None) is not None:
+        sock = context.project_dir / ".guru" / "guru.sock"
+        pid = context.project_dir / ".guru" / "guru.pid"
+        with contextlib.suppress(FileNotFoundError):
+            sock.unlink()
+        with contextlib.suppress(FileNotFoundError):
+            pid.unlink()
+
+
+def _trigger_index_and_wait(context, timeout: float = 60.0) -> dict:
+    from environment import _trigger_and_wait_index
+
+    job = _trigger_and_wait_index(context.project_dir, timeout=timeout)
+    context.last_index_job = job
+    return job
+
+
+# ---------------------------------------------------------------------------
+# GIVEN
+# ---------------------------------------------------------------------------
+
+
+@given('the "{name}" fixture project is copied to a tmpdir')
+def step_copy_fixture(context, name):
+    src = _FIXTURES_DIR / name
+    assert src.is_dir(), f"Fixture {name!r} not found at {src}"
+
+    tmp_root = Path(tempfile.mkdtemp(prefix=f"g_{name}_", dir="/tmp"))
+    dst = tmp_root / name
+    shutil.copytree(src, dst)
+    context.project_dir = dst
+    context._polyglot_tmp_root = tmp_root
+
+
+@given("graph is enabled")
+def step_graph_enabled(context):
+    _set_graph_enabled(context.project_dir, True)
+    _start_server_for_context(context)
+
+
+@given("graph is disabled")
+def step_graph_disabled(context):
+    _set_graph_enabled(context.project_dir, False)
+    _start_server_for_context(context)
+
+
+# ---------------------------------------------------------------------------
+# WHEN
+# ---------------------------------------------------------------------------
+
+
+@when("I run 'guru index'")
+def step_run_index(context):
+    context.last_index_job = _trigger_index_and_wait(context)
+
+
+# ---------------------------------------------------------------------------
+# THEN — graph_optional subset (no Neo4j required)
+# ---------------------------------------------------------------------------
+
+
+@then("the index command succeeds")
+def step_index_ok(context):
+    job = getattr(context, "last_index_job", None)
+    assert job is not None, "no index job recorded"
+    assert job.get("status") == "completed", (
+        f"expected status=completed, got {job.get('status')}: {job}"
+    )
+
+
+@then("the server status reports graph_reachable = {val}")
+def step_server_status_graph_reachable(context, val):
+    import httpx
+
+    socket_path = str(context.project_dir / ".guru" / "guru.sock")
+    transport = httpx.HTTPTransport(uds=socket_path)
+    with httpx.Client(transport=transport, timeout=5.0) as client:
+        data = client.get("http://localhost/status").json()
+    expected = val.lower() in ("true", "yes", "1")
+    assert bool(data.get("graph_reachable")) is expected, (
+        f"graph_reachable={data.get('graph_reachable')}, expected {expected}: {data}"
+    )
+
+
+@then("the server status reports graph_enabled = {val}")
+def step_server_status_graph_enabled(context, val):
+    import httpx
+
+    socket_path = str(context.project_dir / ".guru" / "guru.sock")
+    transport = httpx.HTTPTransport(uds=socket_path)
+    with httpx.Client(transport=transport, timeout=5.0) as client:
+        data = client.get("http://localhost/status").json()
+    expected = val.lower() in ("true", "yes", "1")
+    assert bool(data.get("graph_enabled")) is expected, (
+        f"graph_enabled={data.get('graph_enabled')}, expected {expected}: {data}"
+    )
+
+
+@then("no guru-graph daemon was spawned")
+def step_no_daemon_spawned(context):
+    """With graph disabled, the server should not spawn the graph daemon.
+
+    We verify indirectly: the server's graph_client is None (see next step)
+    AND no daemon socket/pid was created under the isolated GURU_GRAPH_HOME
+    (if the surrounding test harness set one). This scenario only runs under
+    the default configuration so we assert the app-level invariant.
+    """
+    import httpx
+
+    socket_path = str(context.project_dir / ".guru" / "guru.sock")
+    transport = httpx.HTTPTransport(uds=socket_path)
+    with httpx.Client(transport=transport, timeout=5.0) as client:
+        data = client.get("http://localhost/status").json()
+    # If the daemon had been spawned, graph_reachable would be true.
+    assert data.get("graph_reachable") is False, f"graph unexpectedly reachable: {data}"
+
+
+@then("the server's graph client is None")
+def step_graph_client_is_none(context):
+    """When config disables the graph, the app builds no GraphClient."""
+    import httpx
+
+    socket_path = str(context.project_dir / ".guru" / "guru.sock")
+    transport = httpx.HTTPTransport(uds=socket_path)
+    with httpx.Client(transport=transport, timeout=5.0) as client:
+        data = client.get("http://localhost/status").json()
+    assert data.get("graph_enabled") is False, f"expected graph_enabled=False, got {data}"
+    assert data.get("graph_reachable") is False, f"expected graph_reachable=False, got {data}"
+
+
+# ---------------------------------------------------------------------------
+# THEN — artifact_indexing (Markdown-only subset, @real_neo4j)
+# ---------------------------------------------------------------------------
+
+
+def _neo4j_driver():
+    """Return a Neo4j driver pointed at GURU_NEO4J_BOLT_URI or default localhost."""
+    from neo4j import GraphDatabase
+
+    uri = os.environ.get("GURU_NEO4J_BOLT_URI", "bolt://127.0.0.1:7687")
+    return GraphDatabase.driver(uri, auth=None)
+
+
+@then('(:Document {{id: "{doc_id}"}}) exists in the graph')
+def step_document_exists(context, doc_id):
+    driver = _neo4j_driver()
+    try:
+        with driver.session() as session:
+            result = session.run(
+                "MATCH (d:Document {id: $id}) RETURN d.id AS id",
+                id=doc_id,
+            )
+            records = list(result)
+            assert records, f"no Document with id={doc_id!r} found in the graph"
+    finally:
+        driver.close()
+
+
+@then("at least one (:MarkdownSection) node under {rel_path} exists")
+def step_markdown_sections_exist(context, rel_path):
+    driver = _neo4j_driver()
+    try:
+        with driver.session() as session:
+            result = session.run(
+                """
+                MATCH (d:Document)-[:CONTAINS*1..]->(s:MarkdownSection)
+                WHERE d.relative_path = $rel_path
+                RETURN count(s) AS n
+                """,
+                rel_path=rel_path,
+            )
+            record = result.single()
+            n = record["n"] if record else 0
+            assert n > 0, f"no MarkdownSection nodes under {rel_path!r} (count={n})"
+    finally:
+        driver.close()
+
+
+@then('LanceDB contains chunks for {rel_path} with kind="{kind}"')
+def step_lancedb_has_chunks(context, rel_path, kind):
+    import lancedb
+
+    db_path = context.project_dir / ".guru" / "db"
+    db = lancedb.connect(str(db_path))
+    try:
+        tables = db.table_names()
+    except Exception:
+        tables = []
+    assert tables, f"no LanceDB tables found under {db_path}"
+    # The chunks table is typically named "chunks" in guru-server. Fall back
+    # to the first table if naming differs — scenario-level assertions only
+    # care about chunk content, not the table name.
+    table_name = "chunks" if "chunks" in tables else tables[0]
+    table = db.open_table(table_name)
+    df = table.to_pandas()
+    # file_path is stored as the absolute on-disk path — use suffix match.
+    mask_path = df["file_path"].astype(str).str.endswith(rel_path)
+    mask_kind = df["kind"].astype(str) == kind
+    matching = df[mask_path & mask_kind]
+    assert len(matching) > 0, (
+        f"no LanceDB rows match file_path~={rel_path!r} kind={kind!r}; "
+        f"columns present: {list(df.columns)}; "
+        f"unique kinds: {sorted(df['kind'].astype(str).unique().tolist())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fallback "I run 'guru X'" via CLI subprocess (not used by the PR-2 subset
+# but handy for future scenarios).
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(args: list[str], cwd: Path) -> tuple[int, str]:
+    result = subprocess.run(
+        ["uv", "run", "guru", *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        env=os.environ.copy(),
+        timeout=60,
+    )
+    return result.returncode, result.stdout + result.stderr

--- a/tests/e2e/features/steps/artifact_steps.py
+++ b/tests/e2e/features/steps/artifact_steps.py
@@ -108,6 +108,8 @@ def step_copy_fixture(context, name):
     src = _FIXTURES_DIR / name
     assert src.is_dir(), f"Fixture {name!r} not found at {src}"
 
+    # Short /tmp path keeps UDS socket paths under the macOS 104-byte
+    # AF_UNIX limit. Matches the convention in tests/e2e/features/environment.py.
     tmp_root = Path(tempfile.mkdtemp(prefix=f"g_{name}_", dir="/tmp"))
     dst = tmp_root / name
     shutil.copytree(src, dst)

--- a/tests/e2e/features/steps/graph_steps.py
+++ b/tests/e2e/features/steps/graph_steps.py
@@ -69,7 +69,7 @@ def step_post_unknown_kind(context):
     context.last_response = context._client.post(
         "/kbs/alpha/links",
         json={"to_kb": "beta", "kind": "sorta_related"},
-        headers={"X-Guru-Graph-Protocol": "1.0.0"},
+        headers={"X-Guru-Graph-Protocol": "1.1.0"},
     )
 
 

--- a/tests/e2e/fixtures/polyglot/api/openapi.yaml
+++ b/tests/e2e/fixtures/polyglot/api/openapi.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.3
+info:
+  title: Polyglot API
+  version: 1.0.0
+paths:
+  /users/{id}:
+    get:
+      operationId: getUser
+      summary: Get user by id
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserResource"
+components:
+  schemas:
+    UserResource:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }

--- a/tests/e2e/fixtures/polyglot/docs/guide.md
+++ b/tests/e2e/fixtures/polyglot/docs/guide.md
@@ -1,0 +1,13 @@
+# Polyglot guide
+
+## Overview
+
+This is a tiny fixture project.
+
+## Auth
+
+See `pkg.auth`.
+
+### Token refresh
+
+Tokens refresh on every login.

--- a/tests/e2e/fixtures/polyglot/guru.json
+++ b/tests/e2e/fixtures/polyglot/guru.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "name": "polyglot",
+  "rules": [
+    { "ruleName": "code", "match": { "glob": "src/**/*.py" } },
+    { "ruleName": "docs", "match": { "glob": "docs/**/*.md" } },
+    { "ruleName": "api", "match": { "glob": "api/**/*.yaml" } }
+  ]
+}

--- a/tests/e2e/fixtures/polyglot/src/pkg/auth.py
+++ b/tests/e2e/fixtures/polyglot/src/pkg/auth.py
@@ -1,0 +1,12 @@
+"""Auth helpers."""
+import hashlib
+
+from pkg.services.user import UserService
+
+
+class AuthError(Exception):
+    pass
+
+
+def hash_password(pw: str) -> str:
+    return hashlib.sha256(pw.encode()).hexdigest()

--- a/tests/e2e/fixtures/polyglot/src/pkg/services/user.py
+++ b/tests/e2e/fixtures/polyglot/src/pkg/services/user.py
@@ -1,0 +1,14 @@
+"""User domain."""
+
+
+class UserBase:
+    def greet(self) -> str:
+        return "hi"
+
+
+class UserService(UserBase):
+    def login(self, user: str, pw: str) -> bool:
+        return True
+
+    def deprecated_fn(self) -> None:
+        pass

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -102,6 +102,10 @@ def mock_embedder():
 @pytest.fixture
 def client(project, mock_embedder):
     config = resolve_config(project_root=project)
+    # Disable graph so indexing doesn't try to auto-start a guru-graph daemon
+    # (which would block on connect_or_spawn for the full ready timeout when
+    # no daemon is reachable, slowing the test past its deadline).
+    config.graph = None
     store = VectorStore(db_path=str(project / ".guru" / "db"))
     app = create_app(
         store=store,


### PR DESCRIPTION
## Summary
- Adds the m0002 Neo4j schema (10 uniqueness constraints + 8 indexes) and bumps protocol `1.0.0 → 1.1.0` / schema `1 → 2` so artifact-graph nodes can land.
- Introduces the `ArtifactOpsBackend` protocol with in-memory `FakeBackend` and Cypher-backed `Neo4jBackend` implementations; adds `IngestService` + `POST /ingest/parse-result` + `DELETE /ingest/documents/{doc_id}` with orphan-preserving reconciliation.
- Wires `BackgroundIndexer` to submit every `ParseResult` via `GraphClient` + `graph_or_skip`, so a Markdown-only index run now materializes `(:Document)` + `(:MarkdownSection)` nodes end-to-end when the graph is enabled.

## Test plan
- [x] `make lint`
- [x] `make test` — 502 passed, 12 skipped (all `@real_neo4j` / `@slow` opt-ins)
- [x] `make test-graph` — 118 pytest passed + `behave graph_plugin.feature` 6/6 pass (ephemeral `neo4j:5` via `scripts/start-test-neo4j.sh`)
- [x] `behave tests/e2e/features/graph_plugin.feature` — 3/3 pass, 3 `@real_neo4j` skip (without Neo4j); all 6 pass with Neo4j
- [x] `behave tests/e2e/features/graph_cli_reads.feature` — 4/4 pass, 5 `@real_neo4j` skip
- [x] `behave tests/e2e/features/graph_optional.feature` — 2/2 pass, 3 `@skip_until_*` skip
- [x] `behave tests/e2e/features/artifact_indexing.feature --tags=~@skip_until_pr7 --tags=~@skip_until_pr8` — 1/1 `@real_neo4j` Markdown scenario passes against live Neo4j; 6 Python/OpenAPI scenarios skipped until PR-7/8

See design spec §Graph schema and §Parser contract + ingestion + LanceDB in `docs/superpowers/specs/2026-04-18-artifact-graph-knowledge-base-design.md`; plan in `docs/superpowers/plans/2026-04-18-artifact-graph-knowledge-base.md`.

Generated with Claude Code