### PR TITLE
chore: ignore Claude AI worktree artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 .worktrees/
 packages/guru-web/dist/
 packages/guru-web/node_modules/
+
+.claude/worktrees/


### PR DESCRIPTION
Exclude generated worktree directory from version control to prevent tracking of temporary AI-generated development artifacts.
